### PR TITLE
Grungecodes Flamethrowers (Flamer projectile hotfix)

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -39,6 +39,7 @@
 	icon_state = "3"
 	light_range = LIGHT_RANGE_FIRE
 	light_color = LIGHT_COLOR_FIRE
+	flag = "bullet"
 	damage_type = BURN
 	damage = 12 //slight damage on impact
 	range = 10

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -41,7 +41,7 @@
 	light_color = LIGHT_COLOR_FIRE
 	flag = "bullet"
 	damage_type = BURN
-	damage = 12 //slight damage on impact
+	damage = 10 //slight damage on impact
 	range = 10
 
 /obj/item/projectile/incendiary/flamethrower/on_hit(atom/target)


### PR DESCRIPTION
## About The Pull Request

Grungecodes the flamethrower into oblivion

Turns out the flamethrower projectile had no damage flag, so it just skipped armor checks, very funny.

Gave it the bullet flag so armor is actually accounted for.
On Cornercube's suggestion, nerfed it from 12x6 to 10x6 damage. It's still a 2 tap against unarmored targets, though against most armored opponents, it's a 3 tap. This is entirely ignoring afterburn.

## Why It's Good For The Game

Please see below
Centurion 2 tap crit, 4 tap kill
![ezgif-3-0ad4331aaf](https://user-images.githubusercontent.com/72716882/215650700-f5502011-9c6c-4004-af62-6fb555a044b0.gif)
Head Paladin (Heavy PA, better than normal, powered PA) down in 4 seconds flat
![ezgif-3-c18519f75a](https://user-images.githubusercontent.com/72716882/215650779-b182a989-f6d0-44df-a11e-6be5386238d0.gif)

Oversight bad, that's why it's good for the game

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog
:cl:
tweak: tweaked the flamethrower
/:cl:


