### PR TITLE
Nerfs Flamer

### DIFF
--- a/code/modules/projectiles/guns/ballistic/flamethrower.dm
+++ b/code/modules/projectiles/guns/ballistic/flamethrower.dm
@@ -98,14 +98,14 @@
 	icon_state = "m2_flamethrower_on"
 	item_state = "m2flamethrower"
 	flags_1 = CONDUCT_1
-	slowdown = 0.5
+	slowdown = 1
 	slot_flags = null
 	w_class = WEIGHT_CLASS_HUGE
 	custom_materials = null
 	burst_size = 2
 	burst_shot_delay = 1
 	//automatic = 0
-	fire_delay = 2
+	fire_delay = 5
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/flamethrower.ogg'
 	mag_type = /obj/item/ammo_box/magazine/internal/m2flamethrower

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -40,7 +40,7 @@
 	light_range = LIGHT_RANGE_FIRE
 	light_color = LIGHT_COLOR_FIRE
 	damage_type = BURN
-	damage = 12 //slight damage on impact
+	damage = 5 //slight damage on impact
 	range = 10
 
 /obj/item/projectile/incendiary/flamethrower/on_hit(atom/target)


### PR DESCRIPTION
Howdy, my names Bard. I added the flamer way back on fortune. In the time since:

The Damage has been increased by 125%
The thermal cap has been increased by 200%
The fire rate has been increased by 500%
The slowdown has been decreased by 50%

This effectively turned it from it's original design intent as a support weapon, which I extensively documented in the original PR, into a fast firing flame shotgun that does 72 damage, 5 firestacks, and ignores all armor, letting engineers solo entire battles even against the most well equipped opponents.

This nerf returns it closer to it's original design intent. It increases the slowdown, lowers the damage, and lowers the rate of fire. The thermal cap was originally too low, so it being buffed is fine. This should bring it back to it's original use as a support weapon instead of death, destroyer of worlds as it is now.

Here's the original PR by the by
https://github.com/fortune13-ss13/Fortune13/pull/174/files#diff-e11ec94ac4f37841eceb81c9ffb87b74afaff596acac5b24c4eda7b7bc814f7e