### PR TITLE
Buffs Trail Ranger

### DIFF
--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -523,7 +523,7 @@
 	icon_state = "cowboyrang"
 	item_state = "cowboyrang"
 	armor = list("melee" = 25, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0, "wound" = 40)
-	slowdown = 0.01
+	slowdown = -0.14
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 4)
 
 /obj/item/clothing/suit/armor/f13/trailranger/Initialize()

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -554,14 +554,14 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 /datum/outfit/loadout/rangertrail
 	name = "Trail Ranger"
-	suit = /obj/item/clothing/suit/armor/f13/trailranger
+	suit = /obj/item/gun/ballistic/rifle/repeater/trail
 	belt = /obj/item/storage/belt/military/NCR_Bandolier
 	neck = /obj/item/clothing/neck/mantle/ranger
 	suit_store = /obj/item/gun/ballistic/rifle/repeater/cowboy
 	backpack_contents = list(
 		/obj/item/storage/box/ration/ranger_lunch = 1,
 		/obj/item/gun/ballistic/revolver/colt357 = 1,
-		/obj/item/ammo_box/tube/a357 = 4
+		/obj/item/ammo_box/tube/m44 = 4
 		)
 
 /datum/outfit/loadout/rangerpatrol

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -554,10 +554,10 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 /datum/outfit/loadout/rangertrail
 	name = "Trail Ranger"
-	suit = /obj/item/gun/ballistic/rifle/repeater/trail
+	suit = /obj/item/clothing/suit/armor/f13/trailranger
 	belt = /obj/item/storage/belt/military/NCR_Bandolier
 	neck = /obj/item/clothing/neck/mantle/ranger
-	suit_store = /obj/item/gun/ballistic/rifle/repeater/cowboy
+	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail
 	backpack_contents = list(
 		/obj/item/storage/box/ration/ranger_lunch = 1,
 		/obj/item/gun/ballistic/revolver/colt357 = 1,


### PR DESCRIPTION




## About The Pull Request

Buffs trail ranger loadout. Armor now has a very slight speed bonus. It's somewhat noticeable when racing with other players. The cowboy repeater is replaced with a Trail carbine.

## Why It's Good For The Game

The Cowboy Repeater is really bad it's basically a two-handed .44 magnum revolver with slowdown.  Trail ranger armor has lower armor for no tangible benefit besides drip. Now it has a benefit for its lower armor compared to other ranger loadouts.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:

tweak: Trail ranger loadout has a Trail carbine and a slight speed buff on the Armor vest.

/:cl: