### PR TITLE
removes the automatic meta

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -171,8 +171,8 @@ ATTACHMENTS
 	var/burst_size = 1
 	/// The time between shots in burst.
 	var/burst_shot_delay = 3
-	/// The time between firing actions, this means between bursts if this is burst weapon. The reason this is 0 is because you are still, by default, limited by clickdelay.
-	var/fire_delay = 0
+	/// The time between firing actions, this means between bursts if this is burst weapon(?) CLICK_CD_RANGE need no longer apply.
+	var/fire_delay = 5
 	//Time between individual shots when firing full-auto.
 	var/autofire_shot_delay = 3
 	/// Last world.time this was fired
@@ -426,7 +426,7 @@ ATTACHMENTS
 		return
 
 	if (automatic == 0)
-		user.DelayNextAction(ranged_attack_speed)
+		user.DelayNextAction(fire_delay)
 	if (automatic == 1)
 		user.DelayNextAction(autofire_shot_delay)
 
@@ -468,7 +468,7 @@ ATTACHMENTS
 
 /obj/item/gun/proc/get_clickcd()
 	if (automatic == 0)
-		return isnull(chambered?.click_cooldown_override)? CLICK_CD_RANGE : chambered.click_cooldown_override
+		return isnull(chambered?.click_cooldown_override)? fire_delay : chambered.click_cooldown_override
 	if (automatic == 1)
 		return isnull(chambered?.click_cooldown_override)? autofire_shot_delay : chambered.click_cooldown_override
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Removes the arbitrary firerate lock on semi-autos, draft PR for obvious reasons.

I won't be working on this for a bit because I'll be too busy playing the Mojave Sun test.

## Why It's Good For The Game

The age of man is at an end... (automatics will retain their "hold left click" functionality instead of being objectively better in every respect.)

Probably an NCR buff, so speedmerge.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
balance: Fire delay for semi-automatics is no longer locked to a minimum of 500ms.
fix: Fire delay for semi-automatics is no longer locked to a minimum of 500ms.
tweak: Fire delay for semi-automatics is no longer locked to a minimum of 500ms.
/:cl:
