### PR TITLE
Fix: Brah-Min Sprite

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -76,8 +76,8 @@
 	name = "Brah-Min"
 	desc = "A large, docile supermutant. Adopted by Kebab-town as a sort of watch dog for their brahmin herd."
 	icon = 'icons/fallout/mobs/supermutant.dmi'
-	icon_state = "hulk_brahmin_s"
-	icon_dead = "hulk_brahmin_s"
+	icon_state = "mutant_private"
+	icon_dead = "mutant_private"
 	maxHealth = 300
 	health = 300
 	speak_chance = 7 //30 //Oh my god he never shuts up.

--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -86,7 +86,7 @@
 	speak = list("Hey! These my brahmins!", "And I say, HEY-YEY-AAEYAAA-EYAEYAA! HEY-YEY-AAEYAAA-EYAEYAA! I SAID HEY, what's going on?", "What do you want from my brahmins?!", "Me gonna clean brahmin poop again now!", "I love brahmins, brahmins are good, just poop much!", "Do not speak to my brahmins ever again, you hear?!", "Bad raiders come to steal my brahmins - I crush with shovel!", "Do not come to my brahmins! Do not touch my brahmins! Do not look at my brahmins!", "I'm watching you, and my brahmins watch too!", "Brahmins say moo, and I'm saying - hey, get your ugly face out of my way!", "I... I remember, before the fire... THERE WERE NO BRAHMINS!", "No! No wind brahmin here! Wind brahmin lie!")
 	speak_emote = list("shouts", "yells")
 	emote_hear = list("yawns", "mumbles","sighs")
-	emote_see = list("raises his shovel", "shovels some dirt away", "waves his shovel above his head angrily")
+	emote_see = list("raises his fist", "shovels some dirt away", "waves his fist above his head angrily")
 	response_help_simple  = "touches"
 	response_disarm_simple = "pushes"
 	response_harm_simple   = "punches"


### PR DESCRIPTION


## About The Pull Request
Makes Brah-Min have a sprite instead of being a mute. 
![image](https://github.com/Foundation-19/Big-Iron/assets/29418371/2c156afd-3f48-4083-8280-2e67cf2d6d2c)

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
bug fix: brah-Min has sprite now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
