### PR TITLE
Reintroduced dungeons and loot

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -16,6 +16,22 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"aee" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/shard{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/awaymission/caves)
 "aei" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/deathclaw/legendary{
@@ -87,6 +103,21 @@
 /obj/item/reagent_containers/pill/patch/bitterdrink,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ala" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"anP" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "aoW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred/side{
@@ -136,6 +167,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"ayu" = (
+/obj/machinery/computer/security{
+	dir = 4;
+	network = "vault"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "azq" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
@@ -151,6 +191,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"aGj" = (
+/obj/item/chair,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "aGE" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -161,6 +205,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"aHT" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "aIj" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 4
@@ -190,6 +242,13 @@
 "aJk" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/bunker)
+"aJl" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "aJE" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -211,6 +270,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"aNQ" = (
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "aNR" = (
 /obj/item/storage/fancy/rollingpapers,
 /obj/effect/decal/cleanable/dirt,
@@ -232,6 +302,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"aPd" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "library"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "aQB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -351,6 +429,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"aYY" = (
+/obj/machinery/autolathe,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "baj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -363,6 +447,9 @@
 "bbg" = (
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"bbP" = (
+/turf/closed/indestructible/fakeglass,
+/area/awaymission/caves)
 "bcs" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -378,6 +465,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"beY" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
+"bhM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "bil" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
@@ -393,11 +496,25 @@
 /mob/living/simple_animal/hostile/supermutant/legendary,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"bjK" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "bkV" = (
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
 /area/f13/bunker)
+"blz" = (
+/obj/structure/ladder/unbreakable{
+	desc = "An extremely sturdy metal ladder. This one leads back up through the shattered ceiling plating.";
+	height = 1;
+	id = "Bigchewchewbunker"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/underground/cave)
 "blF" = (
 /obj/effect/landmark/map_load_mark/dungeons/oasisbunker,
 /turf/closed/indestructible/rock,
@@ -492,6 +609,13 @@
 /obj/structure/nest/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"bsA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/gas/enclave,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "bsL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/trash_stack,
@@ -575,6 +699,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"bzq" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "bAq" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -704,6 +832,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"bPt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "bluemark"
+	},
+/area/awaymission/caves)
 "bPQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -729,11 +864,24 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"bQu" = (
+/obj/structure/closet/crate/large,
+/obj/item/multitool,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "bQH" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/bunker)
+"bRz" = (
+/obj/structure/junk/small/bed,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "bRG" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -780,6 +928,17 @@
 "bTS" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/underground/cave)
+"bTX" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/shard{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "bUg" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -941,6 +1100,10 @@
 	},
 /turf/closed/indestructible/rock,
 /area/f13/bunker)
+"ckS" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "clD" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
@@ -950,6 +1113,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"cnM" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "coH" = (
 /obj/structure/sign/warning,
 /obj/effect/decal/cleanable/dirt,
@@ -964,10 +1130,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"coX" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/securitron/nsb{
+	health = 400;
+	loot = list(/obj/item/keycard/nml1);
+	maxHealth = 400;
+	name = "Securi-chew"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "cqu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/item/organ/ears/cat,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "cqM" = (
@@ -1030,6 +1211,11 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
+"cwc" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/awaymission/caves)
 "cwn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood{
@@ -1069,6 +1255,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/radiation)
+"cDZ" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "cEm" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -1236,6 +1431,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"cVv" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/awaymission/caves)
 "cVI" = (
 /obj/structure/flora/stump,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -1243,6 +1445,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"cWx" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "cWF" = (
 /obj/structure/sink{
 	dir = 8;
@@ -1472,6 +1681,13 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"drY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "dtr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/water_purifier,
@@ -1484,6 +1700,12 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/bunker)
+"dtL" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "dtT" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -1515,6 +1737,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"dwq" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "dwV" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -1535,6 +1763,22 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/bunker)
+"dyc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/bed/old,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
+"dyj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "dzs" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -1545,6 +1789,19 @@
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"dAq" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/awaymission/caves)
+"dAu" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "dBj" = (
 /obj/structure/chair/middle{
 	dir = 1
@@ -1611,6 +1868,14 @@
 /obj/structure/lattice,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"dGX" = (
+/obj/structure/chair/f13chair2{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "dHD" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -1776,6 +2041,9 @@
 /obj/structure/simple_door,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"dRq" = (
+/turf/closed/indestructible/rock,
+/area/awaymission/caves)
 "dRt" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -2022,6 +2290,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"elk" = (
+/obj/item/chair,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "elw" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2064,6 +2338,13 @@
 	icon_state = "horizontalbottomborderbottom2right"
 	},
 /area/f13/wasteland)
+"eri" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/awaymission/caves)
 "erz" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2077,6 +2358,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"esR" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "esZ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -2128,6 +2418,15 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
+"ewK" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/awaymission/caves)
 "exv" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2153,6 +2452,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"exW" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "eyh" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/building)
@@ -2244,6 +2549,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"eDm" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "eEr" = (
 /obj/structure/timeddoor,
 /obj/effect/decal/cleanable/dirt,
@@ -2260,6 +2573,11 @@
 	icon_state = "2-i"
 	},
 /area/f13/bunker)
+"eEG" = (
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "eFo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -2272,6 +2590,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"eGi" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "eGm" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -2339,6 +2663,23 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"ePE" = (
+/obj/machinery/workbench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"ePK" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/awaymission/caves)
 "ePM" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/light/small{
@@ -2357,6 +2698,16 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
+"eQW" = (
+/obj/structure/table,
+/obj/item/gun/energy/laser/plasma/glock,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "eSi" = (
 /obj/structure/toilet{
 	dir = 4
@@ -2389,6 +2740,19 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
+"eWO" = (
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
+"eXH" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "eXZ" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -2440,6 +2804,16 @@
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"fcE" = (
+/obj/machinery/power/tesla_coil/research{
+	desc = "A modified military-grade tesla coil constantly exchanging energy throughout. It looks to be recently used.";
+	name = "tesla charge inducer"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "fdt" = (
 /obj/machinery/power/deck_relay,
 /turf/open/floor/plating/tunnel{
@@ -2526,6 +2900,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"fpA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "fqf" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/structure/barricade/wooden/strong,
@@ -2534,6 +2915,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"fqg" = (
+/turf/closed/indestructible/vaultdoor{
+	desc = "A wall made out of metal, really fucking tough metal. Someone built this waaaay in advance.";
+	name = "bunker wall"
+	},
+/area/awaymission/caves)
 "fqn" = (
 /obj/structure/chair/stool/retro/tan,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -2565,6 +2952,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"fvJ" = (
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "fvN" = (
 /obj/machinery/door/airlock{
 	name = "Vault 223 Janitorial storage"
@@ -2600,6 +2997,11 @@
 /obj/structure/debris/v3,
 /turf/closed/indestructible/rock,
 /area/f13/bunker)
+"fAb" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/awaymission/caves)
 "fAw" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/carpet/green,
@@ -2653,6 +3055,13 @@
 	dir = 10
 	},
 /area/f13/bunker)
+"fHt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/awaymission/caves)
 "fHM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -2706,6 +3115,13 @@
 /obj/effect/decal/cleanable/glass/plasma,
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"fMH" = (
+/obj/structure/reagent_dispensers/barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "fNA" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/reagent_dispensers/barrel/three,
@@ -2837,6 +3253,15 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"gbQ" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	faction = list("wastebot")
+	},
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "gcc" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2866,6 +3291,15 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"gfd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "gfI" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor4-old"
@@ -2874,6 +3308,13 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"gfT" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "bluemark"
+	},
+/area/awaymission/caves)
 "ggY" = (
 /obj/effect/decal/remains/human,
 /turf/closed/indestructible/rock,
@@ -2902,6 +3343,16 @@
 /obj/effect/mob_spawn/human/corpse,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"gkT" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "glc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -2973,6 +3424,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/bunker)
+"gqk" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "grN" = (
 /obj/structure/table/booth,
 /obj/structure/spacevine{
@@ -2985,6 +3446,8 @@
 /obj/structure/closet/crate/radiation,
 /obj/effect/spawner/lootdrop/f13/armor/tier5,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
+/obj/item/clothing/suit/armored/heavy/salvaged_pa/t60,
+/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t60,
 /turf/open/floor/plating/f13/inside/mountain,
 /area/f13/bunker)
 "gsq" = (
@@ -3009,6 +3472,24 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"gtZ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/awaymission/caves)
+"gvK" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "gwd" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -3064,9 +3545,17 @@
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"gCE" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "gDI" = (
 /obj/structure/closet/crate/radiation,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/effect/spawner/bundle/f13/gauss,
 /turf/open/floor/plating/f13/inside/mountain{
 	icon_state = "mountain2"
 	},
@@ -3086,6 +3575,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"gFR" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "library"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "gGu" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -3173,6 +3670,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
+"gLS" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/awaymission/caves)
 "gMq" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13{
@@ -3263,6 +3766,14 @@
 /obj/item/trash/f13/rotten,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"gWF" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "gYy" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -3271,6 +3782,21 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/bunker)
+"gYA" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/flamer{
+	faction = list("raider");
+	icon_living = "pvtgutsyflamer";
+	icon_state = "pvtgutsyflamer";
+	name = "Corporal Torque"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "gZk" = (
 /obj/machinery/light{
 	dir = 4
@@ -3384,6 +3910,20 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"hfi" = (
+/obj/structure/junk/small/bed,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"hfN" = (
+/obj/structure/ladder/unbreakable{
+	desc = "An extremely sturdy metal ladder. This one leads back up through the shattered ceiling plating.";
+	height = 1;
+	id = "EnclaveBunker"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "hfO" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/barricade/wooden,
@@ -3397,6 +3937,12 @@
 /obj/structure/debris/v3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"hgU" = (
+/mob/living/simple_animal/hostile/securitron/sentrybot,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "hgX" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13{
@@ -3470,6 +4016,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
+"hop" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "library"
+	},
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "hoT" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -3542,6 +4095,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"huy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/awaymission/caves)
 "hvg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor7-old"
@@ -3565,6 +4125,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"hxa" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "hxk" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -3692,6 +4256,12 @@
 "hIH" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/underground/cave)
+"hIJ" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "hIQ" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/barricade/wooden,
@@ -3702,6 +4272,15 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"hKu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "hLj" = (
 /mob/living/simple_animal/hostile/deathclaw/legendary,
 /turf/open/floor/plating/f13/inside/mountain{
@@ -3761,6 +4340,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"hQq" = (
+/obj/structure/table,
+/obj/item/clothing/under/f13/enclave_officer,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "hQQ" = (
 /obj/item/ammo_casing/a762,
 /obj/item/ammo_casing/c9mm,
@@ -3779,6 +4365,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"hSU" = (
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/inside/mountain,
+/area/awaymission/caves)
 "hTk" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -3851,6 +4441,13 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/bunker)
+"hYU" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "hZU" = (
 /obj/machinery/vending/cola/space_up,
 /obj/effect/decal/cleanable/dirt,
@@ -3867,6 +4464,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"icb" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = -4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "icx" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
 /obj/structure/closet/cabinet{
@@ -3885,6 +4492,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"igg" = (
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "igq" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13{
@@ -3906,6 +4518,21 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"ijx" = (
+/obj/item/crowbar,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
+"ilj" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "ilr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
@@ -4016,6 +4643,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"itV" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/awaymission/caves)
 "ivT" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -4048,6 +4681,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"iyy" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "izA" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13{
@@ -4071,6 +4713,14 @@
 /obj/structure/flora/junglebush,
 /turf/open/water,
 /area/f13/tunnel)
+"iAz" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "iAD" = (
 /obj/effect/decal/remains/human,
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -4135,6 +4785,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"iGD" = (
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/awaymission/caves)
 "iGW" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/kebab/human,
@@ -4145,6 +4804,13 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"iJg" = (
+/obj/item/clothing/head/helmet/f13/power_armor/x02helmet,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "iKc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor7-old"
@@ -4462,6 +5128,12 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"jqp" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "jqI" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -4636,6 +5308,13 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"jFZ" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "jHA" = (
 /obj/machinery/power/terminal,
 /obj/effect/decal/cleanable/dirt,
@@ -4678,6 +5357,13 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"jNY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/awaymission/caves)
 "jOh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human{
@@ -4685,6 +5371,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"jPY" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "jQx" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4731,6 +5423,13 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"jTE" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "jTN" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -4957,6 +5656,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
+"kkJ" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "klR" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "suka";
@@ -5010,6 +5717,12 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"krn" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/awaymission/caves)
 "krT" = (
 /mob/living/simple_animal/hostile/raider/thief,
 /turf/open/floor/f13/wood,
@@ -5068,6 +5781,9 @@
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"kuV" = (
+/turf/closed/mineral/random/low_chance,
+/area/awaymission/caves)
 "kvU" = (
 /obj/structure/chair/wood,
 /mob/living/simple_animal/hostile/raider/legendary,
@@ -5115,6 +5831,10 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"kBy" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "kBG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/limb,
@@ -5385,6 +6105,12 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"leC" = (
+/obj/structure/closet/crate/medical,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "leP" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -5559,6 +6285,11 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
+"lqs" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/awaymission/caves)
 "lqU" = (
 /obj/structure/rack,
 /obj/item/assembly/signaler,
@@ -5628,12 +6359,24 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"luW" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/awaymission/caves)
 "lva" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"lvl" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	dir = 6;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "lvt" = (
 /obj/effect/turf_decal/stripes/line,
 /mob/living/simple_animal/hostile/deathclaw{
@@ -5659,6 +6402,12 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"lwE" = (
+/mob/living/simple_animal/hostile/enclave/soldier,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "lxr" = (
 /obj/structure/debris/v3,
 /turf/open/floor/plating/tunnel{
@@ -5722,6 +6471,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
+"lCW" = (
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "lDz" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/cobweb{
@@ -5744,6 +6499,15 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"lFt" = (
+/obj/structure/junk/small/bed2,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/awaymission/caves)
 "lFw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -5900,6 +6664,12 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"lPQ" = (
+/obj/structure/reagent_dispensers/barrel/three{
+	pixel_x = -14
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/awaymission/caves)
 "lQc" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plating/tunnel,
@@ -5909,6 +6679,11 @@
 /obj/item/stack/sheet/metal/ten,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"lRX" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "lSd" = (
 /obj/effect/decal/waste{
 	pixel_x = -4;
@@ -6047,6 +6822,11 @@
 /obj/structure/closet,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"mem" = (
+/obj/structure/junk/small/bed,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "mep" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -6105,6 +6885,15 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"mgq" = (
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/awaymission/caves)
 "miu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder/reinforced,
@@ -6232,6 +7021,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/bunker)
+"mnD" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "mpy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -6254,6 +7050,21 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"mqW" = (
+/mob/living/simple_animal/hostile/enclave/soldier{
+	desc = "A former Enclave soldier, mutated by the forced evolutionary virus and grafted to the interior of his suit.";
+	extra_projectiles = 1;
+	faction = list("wastebot");
+	loot = null;
+	name = "Sergeant Armstrong";
+	speak = list("AUUGHGHHH!");
+	speak_emote = list("shouts")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "mrd" = (
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/floor/plating/tunnel{
@@ -6309,6 +7120,14 @@
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mvf" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "mvA" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtysolid"
@@ -6338,6 +7157,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
+"mxo" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "mxq" = (
 /turf/closed/indestructible/wood{
 	desc = "A wall with wooden plating. Stiff, and knocking on it indictates that the wood is just a covering for some heavily-reinforced machinery."
@@ -6376,6 +7203,12 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"mzI" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "mAs" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "99";
@@ -6422,6 +7255,13 @@
 /obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"mDp" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "mDK" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6457,7 +7297,7 @@
 /area/f13/bunker)
 "mFy" = (
 /obj/effect/decal/remains/human,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/water,
 /area/f13/tunnel)
 "mFX" = (
@@ -6485,6 +7325,9 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/water,
 /area/f13/bunker)
+"mHo" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/awaymission/caves)
 "mIf" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
@@ -6513,6 +7356,14 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"mJq" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "mJS" = (
 /obj/machinery/door/window/southleft,
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -6677,6 +7528,17 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"mST" = (
+/obj/effect/decal/waste,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
+"mUR" = (
+/obj/structure/table,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "mVs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -6741,6 +7603,11 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"mYO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "mZm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6905,6 +7772,10 @@
 	icon_state = "yellowdirtysolid"
 	},
 /area/f13/bunker)
+"nrf" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "nrx" = (
 /obj/effect/turf_decal/stripes/red/full,
 /obj/structure/window/reinforced/spawner/north,
@@ -6935,6 +7806,13 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"nsN" = (
+/obj/structure/closet/crate/large,
+/obj/item/storage/box/stockparts/basic,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "nux" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6991,6 +7869,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/casino)
+"nyx" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "nzV" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/f13/wood{
@@ -7016,6 +7902,10 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"nCX" = (
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/awaymission/caves)
 "nDY" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
@@ -7137,6 +8027,16 @@
 /obj/structure/closet,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"nNh" = (
+/obj/structure/junk/small/bed,
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/awaymission/caves)
 "nNo" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13{
@@ -7197,13 +8097,19 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/item/clothing/gloves/ring/diamond,
 /obj/effect/decal/remains/human,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "nTL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
+"nTX" = (
+/obj/item/stack/cable_coil/cut/random,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "nUv" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
@@ -7226,6 +8132,10 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
+"nWQ" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/mountain,
+/area/awaymission/caves)
 "nYx" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
@@ -7234,6 +8144,14 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
+"nYU" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "nZt" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -7329,6 +8247,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
+"ofE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
+/area/awaymission/caves)
 "ofN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/debris/v4,
@@ -7343,6 +8265,13 @@
 	icon_state = "yellowdirtysolid"
 	},
 /area/f13/bunker)
+"ogo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "ogw" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/pump,
@@ -7378,6 +8307,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"ojW" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "olg" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -7395,6 +8330,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"olw" = (
+/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "omi" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
@@ -7697,6 +8641,12 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
+"oMN" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "oNs" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -7766,6 +8716,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
+"oRZ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "oSu" = (
 /obj/item/stack/sheet/glass/ten,
 /obj/structure/rack,
@@ -7941,6 +8899,12 @@
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"pid" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "piQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
@@ -7966,6 +8930,17 @@
 /obj/structure/lattice,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"pkW" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "plm" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "meat";
@@ -8030,6 +9005,18 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
+"pok" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"ppu" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/awaymission/caves)
 "ppF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
@@ -8084,6 +9071,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"pvX" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
+"pvZ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron{
+	aggro_vision_range = 30;
+	desc = "A prototype assaultron with (visibly) upgraded leg motors and hydraulics. It's painted in Enclave markings.";
+	dir = 4;
+	health = 1500;
+	maxHealth = 1500;
+	name = "PCU-11";
+	speed = -0.5
+	},
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "pxv" = (
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
@@ -8284,6 +9288,12 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/bunker)
+"pPl" = (
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "pPC" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/f13/wood{
@@ -8344,11 +9354,28 @@
 	icon_state = "housewood2"
 	},
 /area/f13/casino)
+"pTZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"pUK" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "pVC" = (
 /obj/machinery/door/airlock/science,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"pWG" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "pWU" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/nest/cazador,
@@ -8504,6 +9531,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"qhQ" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/awaymission/caves)
 "qil" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -8523,6 +9556,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"qko" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "qkw" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13{
@@ -8674,6 +9714,12 @@
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"qxf" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/awaymission/caves)
 "qyH" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
@@ -8702,6 +9748,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"qEQ" = (
+/obj/item/clothing/head/radiation,
+/turf/open/indestructible/ground/inside/mountain,
+/area/awaymission/caves)
 "qHD" = (
 /obj/item/ammo_casing/c9mm,
 /obj/effect/decal/cleanable/dirt,
@@ -8714,6 +9764,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"qKh" = (
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "qLG" = (
 /mob/living/simple_animal/hostile/venus_human_trap{
 	aggro_vision_range = 12;
@@ -8777,6 +9831,12 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"qRX" = (
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "qUi" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/grass/jungle,
@@ -8814,6 +9874,12 @@
 /obj/item/toy/cards/singlecard,
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"rbq" = (
+/obj/machinery/door/window,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "rcs" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck{
@@ -8833,6 +9899,12 @@
 	name = "temple wall"
 	},
 /area/f13/bunker)
+"rdo" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "rey" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/bars,
@@ -8846,11 +9918,22 @@
 	icon_state = "housewood2"
 	},
 /area/f13/casino)
+"rfs" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "rfx" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/plating/tunnel,
 /area/f13/casino)
+"rgb" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/inside/dirt,
+/area/awaymission/caves)
 "rgm" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
@@ -8909,6 +9992,15 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"rkC" = (
+/obj/machinery/power/tesla_coil/research{
+	desc = "A modified military-grade tesla coil constantly exchanging energy throughout. It looks to be recently used.";
+	name = "tesla charge inducer"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "roR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8953,6 +10045,36 @@
 "rri" = (
 /turf/open/water,
 /area/f13/underground/cave)
+"rrk" = (
+/mob/living/simple_animal/hostile/enclave/soldier{
+	aggro_vision_range = 15;
+	armour_penetration = 1;
+	desc = "A grotesque, Enclave-manufactured and Enclave-loyal prime super mutant given cybernetic augmentations, unique hardened power armor, and an arm-mounted plasma repeater, alongside drug cocktails administered by his suit. Your ride's over mutie, time to die.";
+	environment_smash = 2;
+	extra_projectiles = 10;
+	faction = list("wastebot");
+	health = 3000;
+	icon = 'icons/fallout/mobs/bigmob.dmi';
+	icon_dead = "arlem";
+	icon_gib = "arlem";
+	icon_living = "arlem";
+	icon_state = "arlem";
+	loot = list(/obj/item/keycard/library);
+	maxHealth = 3000;
+	melee_damage_lower = 100;
+	melee_damage_upper = 100;
+	melee_queue_distance = 10;
+	name = "Captain Arlem";
+	obj_damage = 300;
+	ranged_ignores_vision = 1;
+	speak = list("Die... mutie!","AAAAUHGHHHH!","DIE!","Perish!","FOR THE ENCLAVE!");
+	speak_chance = 10;
+	speak_emote = list("shouts");
+	speed = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "rrs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
@@ -9044,6 +10166,9 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"rBQ" = (
+/turf/closed/mineral/random/high_chance,
+/area/awaymission/caves)
 "rCA" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -9056,6 +10181,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13,
 /area/f13/bunker)
+"rDN" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/awaymission/caves)
+"rEb" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "rEu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/supermutant/nightkin{
@@ -9076,6 +10217,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"rFF" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "rFH" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant{
 	color = null;
@@ -9161,6 +10313,14 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"rLq" = (
+/obj/effect/decal/cleanable/glass,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "rMd" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9171,6 +10331,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/bunker)
+"rNa" = (
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "rNG" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/decal/cleanable/dirt,
@@ -9224,6 +10391,13 @@
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/water,
 /area/f13/bunker)
+"rPu" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/awaymission/caves)
 "rPU" = (
 /obj/effect/decal/remains/human,
 /obj/item/reagent_containers/syringe,
@@ -9259,6 +10433,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"rSP" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "rTw" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = 102;
@@ -9345,6 +10526,10 @@
 	},
 /turf/open/floor/pod,
 /area/f13/casino)
+"sex" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "sgN" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -9384,11 +10569,24 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"slI" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "slJ" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"smg" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "smT" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -9485,6 +10683,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"stQ" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/awaymission/caves)
 "suz" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -9579,12 +10784,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"sCN" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/inside/mountain,
+/area/awaymission/caves)
 "sEd" = (
 /obj/machinery/door/poddoor/ert{
 	id = "lock1"
 	},
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"sEL" = (
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "sET" = (
 /obj/machinery/door/poddoor/ert{
 	id = "lock1"
@@ -9601,11 +10815,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"sGb" = (
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "bluemark"
+	},
+/area/awaymission/caves)
+"sHg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "sHA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"sIf" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "sID" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/ert{
@@ -9622,6 +10855,12 @@
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"sJT" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "sLK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -9696,6 +10935,20 @@
 /obj/structure/stone_tile/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"sQj" = (
+/obj/machinery/door/window,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"sQz" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtyfull"
+	},
+/area/awaymission/caves)
 "sSd" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
@@ -9705,6 +10958,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"sTX" = (
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "sVo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/ert{
@@ -9745,6 +11001,15 @@
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"sYy" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "sYU" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
@@ -9808,6 +11073,20 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"tiO" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"tma" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "tmr" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/grass/jungle,
@@ -9838,6 +11117,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
+"tnj" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "tns" = (
 /obj/structure/window/plastitanium,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9850,6 +11138,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"toX" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
+"tpC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/awaymission/caves)
 "tqi" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -9947,6 +11248,15 @@
 /obj/structure/stone_tile/slab/burnt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"tyG" = (
+/obj/structure/closet/crate/large,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "tAS" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
@@ -9961,6 +11271,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"tBY" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "tCh" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/water,
@@ -10008,6 +11328,10 @@
 /obj/item/clothing/gloves/combat,
 /turf/open/floor/pod/dark,
 /area/f13/casino)
+"tII" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/inside/mountain,
+/area/awaymission/caves)
 "tJb" = (
 /obj/structure/rack,
 /obj/item/paper/crumpled/bloody{
@@ -10115,6 +11439,14 @@
 /obj/machinery/light/floor,
 /turf/open/floor/pod,
 /area/f13/casino)
+"tTP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "tUL" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -10128,6 +11460,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/casino)
+"tWw" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "tWQ" = (
 /obj/structure/glowshroom/single,
 /obj/structure/flora/ausbushes/brflowers,
@@ -10143,6 +11479,11 @@
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"tXw" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "tXx" = (
 /obj/structure/stone_tile/surrounding,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10173,6 +11514,12 @@
 /obj/item/gun/energy/laser/wattz/magneto,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"uaT" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/cut/random,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "uea" = (
 /obj/machinery/light{
 	dir = 8
@@ -10229,7 +11576,9 @@
 "ujb" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/obj/item/clothing/suit/armor/f13/rangercombat/eliteriot,
+/obj/item/clothing/head/helmet/f13/ncr/rangercombat/eliteriot,
+/obj/item/gun/ballistic/rifle/mag/antimateriel,
 /turf/open/floor/pod/light,
 /area/f13/casino)
 "ujj" = (
@@ -10267,6 +11616,13 @@
 	dir = 1
 	},
 /area/f13/bunker)
+"unE" = (
+/obj/item/stack/cable_coil/random/five,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "unX" = (
 /obj/structure/simple_door/house{
 	icon_state = "glass"
@@ -10280,6 +11636,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"uou" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "uoy" = (
 /obj/structure/table/reinforced,
 /obj/item/trash/f13/rotten,
@@ -10290,6 +11655,10 @@
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"uql" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "urh" = (
 /obj/structure/wreck/trash/machinepile,
 /obj/effect/decal/cleanable/dirt,
@@ -10323,6 +11692,16 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"uvz" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/ammo/ec{
+	pixel_y = 7
+	},
+/obj/item/stock_parts/cell/ammo/ec,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/awaymission/caves)
 "uvX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -10367,6 +11746,12 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"uzv" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "uAt" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10398,6 +11783,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/casino)
+"uGG" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "uHC" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -10410,6 +11804,14 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"uHW" = (
+/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "uIv" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/combat/sneakboots{
@@ -10432,6 +11834,12 @@
 /obj/item/stack/sheet/mineral/wood/twenty,
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"uJJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/awaymission/caves)
 "uKs" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -10499,6 +11907,11 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"uOy" = (
+/mob/living/simple_animal/hostile/securitron/sentrybot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
+/area/awaymission/caves)
 "uOA" = (
 /obj/machinery/workbench/advanced,
 /obj/effect/decal/cleanable/dirt,
@@ -10510,6 +11923,9 @@
 /obj/structure/stone_tile/slab/burnt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"uPP" = (
+/turf/closed/wall/f13/ruins,
+/area/awaymission/caves)
 "uQi" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -10520,6 +11936,13 @@
 /obj/structure/statue/bone/rib,
 /turf/open/water,
 /area/f13/bunker)
+"uQV" = (
+/obj/structure/junk/small/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/awaymission/caves)
 "uRz" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -10536,6 +11959,12 @@
 "uRG" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
+"uRN" = (
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "uSJ" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -10543,6 +11972,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/casino)
+"uTO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "uUH" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -10568,6 +12004,13 @@
 /obj/item/gun/energy/laser/pistol,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"uYr" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/f13{
+	dir = 8;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "uZs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/four_barrels,
@@ -10577,6 +12020,11 @@
 "vak" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/bunker)
+"var" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "vbv" = (
 /obj/machinery/shower{
 	pixel_y = 20
@@ -10664,6 +12112,29 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"vlc" = (
+/mob/living/simple_animal/hostile/ghoul/wyomingghost{
+	desc = "A happily proud Enclave commander, mutated and boiled alive by the forced evolutionary virus. His armor looks to be sunken into his flesh.";
+	faction = list("wastebot");
+	health = 1500;
+	maxHealth = 1500;
+	name = "Commander Dirsk";
+	speak = list("For the Enclave!","Long live America!","Die, mutie!","AAAAAGGH!!","AUGUHGHHH!");
+	speak_chance = 10;
+	speed = -1;
+	unarmed_attack_speed = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"vlS" = (
+/obj/item/beacon/vr/den,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/awaymission/caves)
 "vme" = (
 /obj/structure/stone_tile/block/burnt,
 /obj/item/candle/infinite/hugbox,
@@ -10811,12 +12282,35 @@
 	icon_state = "housewood2"
 	},
 /area/f13/casino)
+"vyF" = (
+/obj/structure/table,
+/obj/item/storage/backpack/enclave{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/storage/backpack/enclave{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "vyR" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/casino)
+"vzJ" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "vAk" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/mask/facehugger/toy,
@@ -10847,6 +12341,14 @@
 /mob/living/simple_animal/hostile/supermutant/legendary,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"vHm" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "vHv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
@@ -10877,10 +12379,25 @@
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"vKl" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/frame,
+/obj/item/stack/cable_coil/cut/random,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "vKu" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vKC" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "vLv" = (
 /obj/structure/stone_tile/surrounding,
 /obj/item/clothing/mask/facehugger/dead,
@@ -10932,6 +12449,14 @@
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"vPY" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
 "vRf" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plating/f13/inside/mountain,
@@ -11089,18 +12614,41 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/bunker)
+"who" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "whp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
 /area/f13/bunker)
+"wml" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "wnC" = (
 /obj/structure/debris/v3,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice,
 /turf/open/water,
 /area/f13/bunker)
+"wqZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/awaymission/caves)
+"wrB" = (
+/obj/structure/junk/small/bed2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/awaymission/caves)
 "wtb" = (
 /obj/item/candle/infinite/hugbox,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11162,6 +12710,10 @@
 	icon_state = "horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
+"wEC" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating/tunnel,
+/area/awaymission/caves)
 "wEM" = (
 /obj/structure/destructible/tribal_torch/wall{
 	dir = 8
@@ -11205,6 +12757,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"wGn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "wGF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine{
@@ -11245,6 +12804,18 @@
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"wLp" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "wNF" = (
 /obj/item/ammo_casing/c9mm,
 /obj/machinery/light/floor,
@@ -11347,6 +12918,13 @@
 /obj/machinery/water_purifier,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
+"wYf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "wZm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/debris/v3,
@@ -11367,12 +12945,25 @@
 "wZU" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
+"xbJ" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "xbP" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"xcM" = (
+/obj/item/clothing/suit/radiation,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "xcZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
@@ -11424,11 +13015,25 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/bunker)
+"xhu" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "xiC" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"xjg" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "xjF" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
@@ -11453,6 +13058,21 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"xmd" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"xnO" = (
+/turf/open/indestructible/ground/inside/dirt,
+/area/awaymission/caves)
+"xov" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "xoK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -11560,6 +13180,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"xEt" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "redmark"
+	},
+/area/awaymission/caves)
 "xEZ" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -11573,6 +13200,17 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"xHE" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "xHO" = (
 /obj/structure/stone_tile/surrounding_tile/burnt{
 	dir = 4
@@ -11610,10 +13248,33 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"xNL" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/indestructible/ground/inside/subway,
+/area/awaymission/caves)
 "xNR" = (
 /obj/item/ammo_box/magazine/m762/empty,
 /turf/open/floor/carpet/green,
 /area/f13/casino)
+"xNT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armor/f13/power_armor/x02,
+/turf/open/floor/f13{
+	dir = 8;
+	icon_state = "bluemark"
+	},
+/area/awaymission/caves)
+"xNY" = (
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/awaymission/caves)
 "xOO" = (
 /obj/structure/weightlifter,
 /turf/open/floor/f13/wood,
@@ -11716,6 +13377,50 @@
 	icon_state = "housewood2"
 	},
 /area/f13/casino)
+"xYI" = (
+/mob/living/simple_animal/hostile/enclave/soldier{
+	desc = "A former Enclave soldier, mutated by the forced evolutionary virus and grafted to the interior of his suit. This one's got a giant ass pulse sniper!";
+	extra_projectiles = 0;
+	faction = list("wastebot");
+	loot = null;
+	name = "Sergeant Mercer";
+	projectiletype = /obj/item/projectile/beam/pulse;
+	ranged_cooldown_time = 24;
+	ranged_message = "fires the pulse sniper";
+	speak = list("AUUGHGHHH!");
+	speak_emote = list("shouts")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"xZu" = (
+/mob/living/simple_animal/hostile/enclave/soldier{
+	desc = "A former Enclave soldier, mutated by the forced evolutionary virus and grafted to the interior of his suit.";
+	extra_projectiles = 1;
+	faction = list("wastebot");
+	loot = null;
+	name = "Private Downs";
+	speak = list("AUUGHGHHH!");
+	speak_emote = list("shouts")
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/awaymission/caves)
+"yaN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/awaymission/caves)
+"ybW" = (
+/turf/open/indestructible/cobble{
+	desc = "An assortment of broken and battered bricks, stones, rebar, and dust.";
+	name = "rubble"
+	},
+/area/awaymission/caves)
 "ycC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/limb,
@@ -17445,51 +19150,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -17702,51 +19407,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+rBQ
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -17959,51 +19664,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+rBQ
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -18216,51 +19921,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+rBQ
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -18473,51 +20178,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+rBQ
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+fqg
+fqg
+fqg
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -18730,51 +20435,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+rBQ
+rBQ
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+fqg
+fqg
+fqg
+pUK
+fqg
+fqg
+fqg
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -18987,51 +20692,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+rBQ
+rBQ
+kuV
+kuV
+kuV
+dRq
+dRq
+fqg
+fqg
+iAz
+igg
+igg
+sEL
+iAz
+fqg
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -19244,51 +20949,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+rBQ
+rBQ
+kuV
+kuV
+kuV
+dRq
+dRq
+fqg
+sEL
+pid
+igg
+igg
+xmd
+pok
+pok
+fqg
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -19501,51 +21206,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+rBQ
+kuV
+kuV
+kuV
+dRq
+fqg
+fqg
+exW
+pok
+ala
+eWO
+jFZ
+pok
+sEL
+fqg
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -19758,51 +21463,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+rBQ
+kuV
+kuV
+dRq
+dRq
+fqg
+hIJ
+itV
+pid
+lCW
+iJg
+rbq
+pok
+igg
+pUK
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -20015,51 +21720,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+rBQ
+kuV
+kuV
+dRq
+dRq
+fqg
+fqg
+qhQ
+lqs
+aHT
+pPl
+cWx
+pid
+sEL
+fqg
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -20272,51 +21977,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+fqg
+cnM
+cnM
+mYO
+qhQ
+pid
+pid
+igg
+fqg
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -20529,51 +22234,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+fqg
+fqg
+ePK
+cnM
+sTX
+sex
+vHm
+fqg
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -20786,51 +22491,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+rBQ
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+fqg
+fqg
+bbP
+aPd
+bbP
+fqg
+fqg
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -21043,51 +22748,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+sEL
+igg
+gkT
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -21300,51 +23005,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+igg
+igg
+mqW
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -21557,51 +23262,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+rdo
+pid
+sEL
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+uPP
+uPP
+uPP
+uPP
+uPP
 heT
 heT
 heT
@@ -21814,51 +23519,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+dRq
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+dwq
+pok
+sEL
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+uPP
+cnM
+cnM
+cnM
+uPP
 heT
 heT
 heT
@@ -22071,51 +23776,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+rBQ
+kuV
+dRq
+dRq
+fqg
+jPY
+dtL
+nNh
+bRz
+fqg
+vPY
+sEL
+tTP
+fqg
+wrB
+gWF
+ppu
+hfi
+fqg
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+uPP
+cnM
+hfN
+cnM
+uPP
 heT
 heT
 heT
@@ -22328,51 +24033,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+rBQ
+kuV
+dRq
+dRq
+fqg
+gCE
+dwq
+iyy
+cnM
+fqg
+igg
+eXH
+igg
+fqg
+lqs
+nrf
+pid
+eXH
+fqg
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+uPP
+cnM
+uzv
+cnM
+uPP
 heT
 heT
 heT
@@ -22585,51 +24290,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+rBQ
+kuV
+dRq
+dRq
+fqg
+igg
+pid
+sEL
+tma
+lvl
+igg
+igg
+sEL
+xEt
+ojW
+sEL
+pok
+bsA
+fqg
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+uPP
+cnM
+cnM
+cnM
+uPP
 heT
 heT
 heT
@@ -22842,51 +24547,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+dRq
+dRq
+fqg
+jNY
+qko
+sEL
+sIf
+fqg
+hgU
+igg
+dGX
+fqg
+tBY
+ojW
+uql
+esR
+fqg
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+uPP
+cnM
+cnM
+cnM
+uPP
 heT
 heT
 heT
@@ -23099,51 +24804,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+dRq
+dRq
+fqg
+toX
+mem
+lFt
+jPY
+fqg
+pid
+gfd
+dGX
+fqg
+jPY
+dyc
+wml
+uQV
+fqg
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+uPP
+cnM
+cnM
+slI
+uPP
 heT
 heT
 heT
@@ -23356,51 +25061,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+dRq
+dRq
+dRq
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+mvf
+sEL
+sYy
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+uPP
+cnM
+cnM
+cnM
+uPP
 heT
 heT
 heT
@@ -23613,51 +25318,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+dRq
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+xjg
+fqg
+fqg
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+uPP
+cnM
+cnM
+cnM
+uPP
 heT
 heT
 heT
@@ -23870,51 +25575,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+dRq
+dRq
+fqg
+nYU
+ayu
+aNQ
+fqg
+fqg
+fqg
+gbQ
+iAz
+sEL
+anP
+rNa
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+cnM
+uzv
+cnM
+uPP
 heT
 heT
 heT
@@ -24127,51 +25832,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+dRq
+dRq
+fqg
+sEL
+hKu
+pid
+igg
+mxo
+fqg
+igg
+igg
+who
+exW
+pok
+fqg
+uYr
+sEL
+anP
+exW
+uPP
+cnM
+tWw
+jTE
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+ckS
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+uPP
 heT
 heT
 heT
@@ -24384,51 +26089,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+dRq
+dRq
+fqg
+sEL
+vlc
+sEL
+who
+pid
+kkJ
+pid
+igg
+uRN
+pid
+sJT
+aJl
+sEL
+igg
+sEL
+hgU
+ybW
+cnM
+tWw
+cnM
+cnM
+cnM
+ckS
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+ckS
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+uPP
 heT
 heT
 heT
@@ -24641,51 +26346,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+dRq
+dRq
+fqg
+gqk
+sEL
+pid
+pid
+uTO
+fqg
+pTZ
+sEL
+dwq
+igg
+bhM
+fqg
+rNa
+dwq
+oRZ
+sEL
+ybW
+ijx
+tWw
+aGj
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+cnM
+slI
+cnM
+uPP
 heT
 heT
 heT
@@ -24898,51 +26603,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+dRq
+dRq
+fqg
+drY
+hQq
+vyF
+fqg
+fqg
+fqg
+mDp
+uou
+sEL
+uou
+gbQ
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
+uPP
 heT
 heT
 heT
@@ -25155,51 +26860,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+dRq
+dRq
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+mnD
+fqg
+fqg
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -25412,51 +27117,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+dRq
+dRq
+dRq
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+mgq
+igg
+iAz
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -25593,6 +27298,10 @@ kFj
 rNG
 acN
 cAW
+wPz
+wPz
+wPz
+wPz
 heT
 heT
 heT
@@ -25665,55 +27374,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+dRq
+dRq
+fqg
+ogo
+pid
+pkW
+xhu
+fqg
+bzq
+sex
+sEL
+fqg
+uGG
+xHE
+fMH
+xov
+fqg
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -25850,6 +27555,10 @@ kKk
 adE
 uND
 wPz
+wPz
+wPz
+blz
+wPz
 heT
 heT
 heT
@@ -25922,55 +27631,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+dRq
+dRq
+fqg
+eGi
+gvK
+eXH
+sEL
+fqg
+cnM
+qhQ
+tiO
+fqg
+leC
+sEL
+wYf
+rfs
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -26107,6 +27812,10 @@ hpz
 xiC
 acN
 drH
+wPz
+wPz
+wPz
+wPz
 heT
 heT
 heT
@@ -26179,55 +27888,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+dRq
+fqg
+igg
+sEL
+pid
+pid
+lvl
+itV
+sTX
+igg
+vzJ
+pid
+uHW
+nyx
+wYf
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -26440,51 +28145,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+dRq
+fqg
+sEL
+lwE
+pok
+unE
+fqg
+sEL
+dwq
+sEL
+fqg
+cDZ
+hYU
+pok
+olw
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -26697,51 +28402,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+dRq
+fqg
+ePE
+aYY
+tyG
+nsN
+fqg
+ilj
+igg
+wEC
+fqg
+bQu
+wLp
+xbJ
+fpA
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+dRq
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -26954,51 +28659,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+dRq
+fqg
+fqg
+fqg
+fqg
+fqg
+fqg
+sEL
+sEL
+lRX
+fqg
+fqg
+fqg
+hop
+fqg
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+gfT
+uvz
+vlS
+var
+qxf
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -27211,51 +28916,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+xZu
+sEL
+itV
+fqg
+dRq
+oMN
+sHg
+xnO
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+gtZ
+luW
+yaN
+eri
+mUR
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -27468,51 +29173,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+sEL
+sEL
+igg
+fqg
+dRq
+hSU
+wqZ
+sHg
+kBy
+gLS
+dRq
+fqg
+fqg
+fqg
+fqg
+fqg
+luW
+huy
+rrk
+tpC
+ewK
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -27725,51 +29430,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+sEL
+sEL
+jqp
+fqg
+dRq
+dRq
+cnM
+wqZ
+sHg
+sHg
+mHo
+fqg
+fcE
+coX
+rkC
+fqg
+luW
+pvZ
+fHt
+rEb
+rSP
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -27982,51 +29687,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+fqg
+fqg
+bbP
+xYI
+aee
+fqg
+fqg
+dRq
+dRq
+xnO
+dAu
+sHg
+cnM
+pvX
+dyj
+xNT
+dyj
+gFR
+luW
+fHt
+dyj
+sQz
+dAq
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -28239,51 +29944,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+fqg
+fqg
+iAz
+sEL
+igg
+sEL
+iGD
+fqg
+fqg
+dRq
+dRq
+dRq
+nCX
+tII
+fqg
+rkC
+gYA
+fcE
+fqg
+dAq
+dAq
+luW
+luW
+mJq
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -28496,51 +30201,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+fqg
+beY
+xNY
+sEL
+vKC
+sEL
+sTX
+cVv
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+fqg
+fqg
+fqg
+fqg
+rPu
+luW
+dAq
+elk
+rDN
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -28753,51 +30458,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+fqg
+fqg
+sEL
+sEL
+vKC
+icb
+bTX
+krn
+sex
+fqg
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+eQW
+stQ
+dyj
+dyj
+smg
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -29010,51 +30715,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+fqg
+pUK
+fvJ
+vKC
+vKC
+rLq
+sQj
+sEL
+pWG
+uaT
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+eEG
+luW
+dyj
+sQz
+dAq
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -29267,51 +30972,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+fqg
+fqg
+igg
+igg
+rFF
+pPl
+vKl
+eDm
+tXw
+fqg
+fqg
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+sGb
+sGb
+bPt
+bPt
+sGb
+fqg
+dRq
+dRq
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -29524,51 +31229,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+fqg
+sEL
+sEL
+sEL
+sEL
+sEL
+igg
+sEL
+pvX
+cnM
+qEQ
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+dAq
+dAq
+dAq
+uJJ
+bjK
+fqg
+dRq
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -29781,51 +31486,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+fqg
+fqg
+oRZ
+igg
+sEL
+nTX
+tnj
+fqg
+fqg
+lPQ
+cnM
+kBy
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+fqg
+sGb
+sGb
+bPt
+bPt
+sGb
+fqg
+dRq
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -30038,51 +31743,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+fqg
+fqg
+fqg
+qRX
+fqg
+fqg
+fqg
+mHo
+sHg
+sHg
+xnO
+cnM
+gLS
+dRq
+dRq
+dRq
+xnO
+sHg
+xnO
+cnM
+mST
+xnO
+mHo
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -30295,51 +32000,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+fqg
+fqg
+fqg
+dRq
+nCX
+xcM
+wGn
+sHg
+xnO
+cnM
+cnM
+nCX
+fAb
+cwc
+sHg
+wqZ
+dAu
+mHo
+hSU
+cnM
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -30552,51 +32257,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+nCX
+rgb
+sHg
+xNL
+ofE
+cnM
+sHg
+ofE
+sHg
+cnM
+hxa
+xnO
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -30809,51 +32514,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+nWQ
+sCN
+mHo
+uOy
+cnM
+mzI
+qKh
+xnO
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -31066,51 +32771,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+rBQ
+rBQ
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -31323,51 +33028,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+rBQ
+rBQ
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT
@@ -31580,51 +33285,51 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+kuV
+kuV
+kuV
+kuV
+kuV
+rBQ
+kuV
+kuV
+rBQ
+rBQ
+kuV
+kuV
+kuV
+rBQ
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+kuV
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
+dRq
 heT
 heT
 heT

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -541,9 +541,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "avu" = (
-/obj/structure/HMG{
-	dir = 4
-	},
+/obj/structure/rack,
+/obj/effect/spawner/bundle/f13/armor/t45d,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "avG" = (
@@ -568,9 +567,9 @@
 /area/f13/bunker)
 "axe" = (
 /obj/structure/closet/crate/secure,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /obj/effect/spawner/lootdrop/f13/blueprintVHighBallistics,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "axA" = (
@@ -1877,7 +1876,7 @@
 "bpY" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -2068,6 +2067,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "yellowrustysolid"
 	},
+/area/f13/enclave)
+"bwC" = (
+/obj/structure/ladder/unbreakable{
+	desc = "An extremely sturdy metal ladder. This one leads back up through the shattered ceiling plating.";
+	height = 1;
+	id = "EnclaveBunker"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "bwM" = (
 /obj/structure/falsewall/rust,
@@ -5196,6 +5203,16 @@
 /obj/structure/decoration/shock,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
+"dMQ" = (
+/obj/structure/ladder/unbreakable{
+	desc = "An extremely sturdy metal ladder. This one leads back up through the shattered ceiling plating.";
+	height = 1;
+	id = "Bigchewchewbunker"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "dNb" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -8770,6 +8787,8 @@
 "glc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
+/obj/item/gun/energy/laser/aer9,
+/obj/item/gun/energy/laser/aer9,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
@@ -9545,6 +9564,12 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	req_access_txt = "1"
+	},
+/obj/item/clothing/head/helmet/f13/combat/swat,
+/obj/item/clothing/head/helmet/f13/combat/swat,
+/obj/item/clothing/suit/space/swat{
+	desc = "A suit jointly developed by the United States military and local police force with the goal of making a suit good for any kind of riot be it a normal riot or an armed conflict, This model never came out of the prototype phase and was outcompeted by a different group who made far better and lighter riot suits which are now most employed by the NCR";
+	name = "Bulky SWAT suit"
 	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
@@ -14435,7 +14460,7 @@
 	pixel_x = -6;
 	pixel_y = 4
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
@@ -16600,6 +16625,7 @@
 "mYL" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/item/locked_box/misc/blueprints/tier3,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mYV" = (
@@ -18113,7 +18139,7 @@
 /obj/effect/decal/waste{
 	icon_state = "goo10"
 	},
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ooF" = (
@@ -19909,6 +19935,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
+"pQb" = (
+/obj/structure/HMG,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "pQq" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
@@ -20172,6 +20202,10 @@
 /obj/item/clothing/under/rank/prisoner,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood)
+"qbo" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier5,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "qcD" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -24032,7 +24066,7 @@
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "tgB" = (
@@ -26230,8 +26264,9 @@
 /area/f13/enclave)
 "vbk" = (
 /obj/effect/turf_decal/bot,
-/obj/item/gun/energy/laser/aer9,
 /obj/structure/rack,
+/obj/item/gun/energy/laser/aer12,
+/obj/item/gun/energy/laser/aer9,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
@@ -35731,7 +35766,7 @@ aoj
 eLE
 aoj
 lAL
-vDN
+qbo
 gpM
 lnr
 xkM
@@ -41864,7 +41899,7 @@ dXE
 dXE
 uPr
 dXE
-fRK
+dMQ
 yiw
 gSS
 rtG
@@ -68164,7 +68199,7 @@ aoj
 ykJ
 dRF
 hBY
-vKj
+bwC
 uRF
 ykJ
 vPg
@@ -69258,7 +69293,7 @@ fLU
 ase
 fxu
 fxu
-fxu
+pQb
 vPg
 vPg
 eLE

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -303,13 +303,14 @@
 	desc = "The Hecate II is a heavy, high-powered bolt action sniper rifle chambered in .50 caliber ammunition. Lacks an iron sight."
 	icon_state = "amr"
 	item_state = "amr"
+	extra_speed = 0
 	mag_type = /obj/item/ammo_box/magazine/amr
 	fire_delay = 12 //Heavy round, tiny bit slower
-	extra_damage = 50
+	extra_damage = 65
 	extra_penetration = 0.6
 	recoil = 1
 	spread = 0
-	force = 65 //Big clumsy and sensitive scope, makes for a poor club
+	force = 10 //Big clumsy and sensitive scope, makes for a poor club
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -264,7 +264,7 @@
 /obj/item/gun/ballistic/rifle/mag
 	name = "magazine fed bolt-action rifle template"
 	desc = "should not exist."
-	extra_speed = 800
+	extra_speed = 0
 
 /obj/item/gun/ballistic/rifle/mag/examine(mob/user)
 	. = ..()
@@ -309,7 +309,7 @@
 	extra_penetration = 0.6
 	recoil = 1
 	spread = 0
-	force = 10 //Big clumsy and sensitive scope, makes for a poor club
+	force = 65 //Big clumsy and sensitive scope, makes for a poor club
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -303,11 +303,11 @@
 	desc = "The Hecate II is a heavy, high-powered bolt action sniper rifle chambered in .50 caliber ammunition. Lacks an iron sight."
 	icon_state = "amr"
 	item_state = "amr"
-	extra_speed = 0
+	extra_speed = 100
 	mag_type = /obj/item/ammo_box/magazine/amr
 	fire_delay = 12 //Heavy round, tiny bit slower
-	extra_damage = 65
-	extra_penetration = 0.6
+	extra_damage = 37
+	extra_penetration = 1
 	recoil = 1
 	spread = 0
 	force = 10 //Big clumsy and sensitive scope, makes for a poor club


### PR DESCRIPTION
## About The Pull Request

Adds a lot of loot to a few places nothing to crazy mostly just re-buffing stuff from when they were nerfed and along with making a few other places feel more like they actually are like they intend to be, like for example the casino vault now actually has a few more guns in it all of the AER variety one 12 and three 9's. 

## Why It's Good For The Game

generally more loot all around so that now you can actually get to be on par with the elite rolls of every faction as a waster instead of how it used to be of all paladins being the only source of functioning PA which is dumb at least in my opinion. 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
Casino vault now sports more armor and three AER-9's and an AER-12 along with two sets of riot armor and the crappy MK-1 SWAT suit you can get from normal SS13 cargo but its renamed to not have a SS13 description.

North sewer bunker has its T-45 power armor back after somebody ninja removed it,

Re-introduced enclave bunker and big chew chew bunker,

Generally buffed loot rewards for higher risk areas that did give dogshit beforehand. (Except on surface)

:cl:
add: Added more things
/:cl:
