### PR TITLE
Double NPC Wait Time

### DIFF
--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(npcpool)
 	flags = SS_KEEP_TIMING | SS_NO_INIT
 	priority = FIRE_PRIORITY_NPC
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
-	wait = 1 SECONDS // currently defines how often mobs attack and flip out
+	wait = 2 SECONDS // currently defines how often mobs attack and flip out
 	// wait = 1 DECISECOND makes retreat/approach mobs just wiggle around in place and cheesegrate people
 
 	var/list/currentrun = list()

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(npcpool)
 	flags = SS_KEEP_TIMING | SS_NO_INIT
 	priority = FIRE_PRIORITY_NPC
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
-	wait = 2 SECONDS // currently defines how often mobs attack and flip out
+	wait = 4 SECONDS // currently defines how often mobs attack and flip out
 	// wait = 1 DECISECOND makes retreat/approach mobs just wiggle around in place and cheesegrate people
 
 	var/list/currentrun = list()


### PR DESCRIPTION
An attempt at fixing the fast-shooting NPCs without nerfing them into the ground.

## About The Pull Request
Sets the NPC wait time from 1 to 2 so the time between shots is doubled, can be tweaked higher if need be.

## Why It's Good For The Game
No more cheese grater rage death.

:code: Set wait = 1 to wait = 2
