### PR TITLE
Revert "nerfs the tribeam"

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -455,7 +455,7 @@
 	desc = "A modified AER9 equipped with a refraction kit that divides the laser shot into three separate beams. While powerful, it has a reputation for friendly fire."
 	icon_state = "tribeam"
 	item_state = "laser-rifle9"
-	fire_delay = 3
+	fire_delay = 4
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter/tribeam/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	equipsound = 'sound/f13weapons/equipsounds/tribeamequip.ogg'

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -455,7 +455,7 @@
 	desc = "A modified AER9 equipped with a refraction kit that divides the laser shot into three separate beams. While powerful, it has a reputation for friendly fire."
 	icon_state = "tribeam"
 	item_state = "laser-rifle9"
-	fire_delay = 5
+	fire_delay = 3
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter/tribeam/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	equipsound = 'sound/f13weapons/equipsounds/tribeamequip.ogg'

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -456,7 +456,7 @@
 
 /obj/item/projectile/beam/laser/tribeam/hitscan
 	name = "tribeam laser"
-	damage = 18 //if all bullets connect, this will do 54
+	damage = 25 //if all bullets connect, this will do 75.
 	hitscan = TRUE
 	bare_wound_bonus = -30 //tribeam is bad at wounding, as basically its only real downside
 	tracer_type = /obj/effect/projectile/tracer/laser


### PR DESCRIPTION
Reverts Foundation-19/Big-Iron#396

This should be handled in a rebalance of all T5 weapons including others like the Plasma Rifle and AMR. fire_delay as a var does not work (I've stated this a multitude of times but the click_CD_ranged define or whatever overwrites it, only automatic fire delay is properly handled in code.)

54 damage for a shotgun is on-par with the T3 lever-action, buckshot ammo has actual wounding and shotgun ammo can't be EMPed to make it useless. This was grudgecode done by somebody who does not understand that the tribeam is ultimately a subpar weapon with eight shots. You can bola the user and disarm him very easily (especially because he's probably wearing power armor), but combat tactics seem regularly overlooked by players who view skill issues as code issues.

To re-iterate: skill issue, ripbozo Paladin gaming for lyfe.