### PR TITLE
Revert "unfucks flamethrower"

### DIFF
--- a/code/modules/projectiles/guns/ballistic/flamethrower.dm
+++ b/code/modules/projectiles/guns/ballistic/flamethrower.dm
@@ -98,7 +98,7 @@
 	icon_state = "m2_flamethrower_on"
 	item_state = "m2flamethrower"
 	flags_1 = CONDUCT_1
-	slowdown = 0.4
+	slowdown = 1
 	slot_flags = null
 	w_class = WEIGHT_CLASS_HUGE
 	custom_materials = null


### PR DESCRIPTION
Reverts Foundation-19/Big-Iron#338

> ![image](https://github.com/Foundation-19/Big-Iron/assets/46099003/5b0d8118-2fb8-489c-8f06-7bffb08897b7)

Merged under false pretenses, Bard absolutely meant to increase the slowdown. This is a support weapon that is probably heavier than an LMG or a SAW truthfully, so the slowdown made sense.
Taken from #207:

> ![image](https://github.com/Foundation-19/Big-Iron/assets/46099003/882da692-1888-4df7-9fb8-547950adcc96)
