### PR TITLE
runtime hunting

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -129,6 +129,7 @@
 		if(require_twohands)
 			to_chat(user, "<span class='notice'>[parent] is too cumbersome to carry in one hand!</span>")
 			user.dropItemToGround(parent, force=TRUE)
+			return
 		else
 			if(!user.dropItemToGround(other_item, force=FALSE)) //If you cannot remove the item in your hand, don't try and wield.
 				to_chat(user, "<span class='notice'>You cannot seem to drop the item in your other hand!</span>")

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -7,7 +7,7 @@
 	var/human_only = TRUE
 	var/gain_text
 	var/locked = FALSE
-	var/lose_text
+	var/lose_text = "<span class='warning'>You feel different...</span>"
 	var/medical_record_text //This text will appear on medical records for the trait. Not yet implemented
 	var/antag_removal_text // Text will be given to the quirk holder if they get an antag that has it blacklisted.
 	var/mood_quirk = FALSE //if true, this quirk affects mood and is unavailable if moodlets are disabled
@@ -35,7 +35,7 @@
 	STOP_PROCESSING(SSquirks, src)
 	remove()
 	if(quirk_holder)
-		to_chat(quirk_holder, lose_text)
+//	to_chat(quirk_holder, lose_text)
 		if(!QDELETED(quirk_holder) && lose_text)
 			to_chat(quirk_holder, lose_text)
 		if(mob_trait)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -14,7 +14,7 @@
 		return
 	do_sparks(rand(5, 9), FALSE, src)
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
-	new /obj/effect/dummy/lighting_obj (flashbang_turf, (flashbang_range + 2), LIGHT_COLOR_WHITE, 4, 2)
+	new /obj/effect/dummy/lighting_obj (flashbang_turf, (flashbang_range + 2), 30, LIGHT_COLOR_WHITE, 4, 2)
 	flashbang_mobs(flashbang_turf, flashbang_range)
 	qdel(src)
 

--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -620,7 +620,7 @@
 
 /obj/item/twohanded/sledgehammer/rockethammer/courtmartial/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
-	if(!proximity || !wielded || IS_STAMCRIT(user))
+	if(!proximity || !wielded || IS_STAMCRIT(user) || QDELETED(A))
 		return
 	if(istype(A, /obj/structure))
 		var/obj/structure/W = A

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -932,8 +932,10 @@
 	/obj/item/twohanded/sledgehammer/simple,
 	/obj/item/melee/transforming/energy/axe/protonaxe,
 	/obj/item/melee/powered/ripper)
-	starting_sword = null
+//	starting_sword = null
 
+/obj/item/storage/belt/sabre/PopulateContents()
+	return
 
 /obj/item/storage/belt/sabre/rapier
 	name = "rapier sheath"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -377,7 +377,7 @@ GLOBAL_LIST_EMPTY(electrochromatic_window_lookup)
 	return TRUE
 
 
-/obj/structure/window/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
+/obj/structure/window/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armour_penetration = 0)
 	. = ..()
 	if(.) //received damage
 		update_nearby_icons()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -197,7 +197,7 @@
 	if(iscarbon(loc))
 		var/mob/living/carbon/C = loc
 		C.visible_message("<span class='danger'>The [zone_name] on [C]'s [src.name] is [break_verb] away!</span>", "<span class='userdanger'>The [zone_name] on your [src.name] is [break_verb] away!</span>", vision_distance = COMBAT_MESSAGE_RANGE)
-		RegisterSignal(C, COMSIG_MOVABLE_MOVED, .proc/bristle)
+		RegisterSignal(C, COMSIG_MOVABLE_MOVED, .proc/bristle, TRUE)
 
 	zones_disabled++
 	for(var/i in zone2body_parts_covered(def_zone))

--- a/code/modules/fallout/misc/gangs.dm
+++ b/code/modules/fallout/misc/gangs.dm
@@ -195,10 +195,10 @@ GLOBAL_DATUM_INIT(greatkhans, /datum/gang/greatkhans, new)
 
 	var/datum/gang/G = gang
 	if(alert(C, "[src] invites you to join the [G.name].", "Gang invitation", "Yes", "No") == "No")
-		visible_message(C, "<span class='warning'>[C.name] refused an offer to join the [G.name]!</span>")
+		C.visible_message("<span class='warning'>[C.name] refused an offer to join the [G.name]!</span>")
 		return
 	else
-		visible_message(C, "<span class='notice'>[C.name] accepted an offer to join the [G.name]!</span>")
+		C.visible_message("<span class='notice'>[C.name] accepted an offer to join the [G.name]!</span>")
 
 	G.add_member(C)
 	C.gang = G

--- a/code/modules/fallout/obj/door_keys.dm
+++ b/code/modules/fallout/obj/door_keys.dm
@@ -89,6 +89,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	layer = 100
 	var/open = FALSE
+	var/locked = TRUE
 	var/id = null
 
 /obj/item/lock/New(location)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -85,14 +85,14 @@
 	if(!wielded)
 		to_chat(user, "<span class='warning'>[src] is too heavy to use with one hand.")
 		return
-	var/datum/status_effect/crusher_damage/C = target.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
+	var/datum/status_effect/crusher_damage/C = new()// = target.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING) F13 WE DONT USE THIS
 	var/target_health = target.health
 	..()
 	for(var/t in trophies)
 		if(!QDELETED(target))
 			var/obj/item/crusher_trophy/T = t
 			T.on_melee_hit(target, user)
-	if(!QDELETED(C) && !QDELETED(target))
+	if(!QDELETED(target))
 		C.total_damage += target_health - target.health //we did some damage, but let's not assume how much we did
 
 /obj/item/kinetic_crusher/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)
@@ -124,13 +124,13 @@
 		var/datum/status_effect/crusher_mark/CM = L.has_status_effect(STATUS_EFFECT_CRUSHERMARK)
 		if(!CM || CM.hammer_synced != src || !L.remove_status_effect(STATUS_EFFECT_CRUSHERMARK))
 			return
-		var/datum/status_effect/crusher_damage/C = L.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
+		var/datum/status_effect/crusher_damage/C = new()// = L.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
 		var/target_health = L.health
 		for(var/t in trophies)
 			var/obj/item/crusher_trophy/T = t
 			T.on_mark_detonation(target, user)
 		if(!QDELETED(L))
-			if(!QDELETED(C))
+			if(C)
 				C.total_damage += target_health - L.health //we did some damage, but let's not assume how much we did
 			new /obj/effect/temp_visual/kinetic_blast(get_turf(L))
 			var/backstab_dir = get_dir(user, L)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -282,7 +282,7 @@ Works together with spawning an observer, noted above.
 		if (!(client.prefs.chat_toggles & CHAT_OOC))
 			client.prefs.chat_toggles ^= CHAT_OOC
 	transfer_ckey(ghost, FALSE)
-	if(!QDELETED(ghost))
+	if(!QDELETED(ghost) && ghost.client)
 		ghost.client.init_verbs()
 	if(penalize)
 		var/penalty = CONFIG_GET(number/suicide_reenter_round_timer) MINUTES

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -31,7 +31,7 @@
 		var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling && changeling.mimicing )
 			return changeling.mimicing
-	if(mind.assigned_role == ("Enclave Remnant" || "Enclave Remnant Medic") && wear_id)
+	if(mind?.assigned_role == ("Enclave Remnant" || "Enclave Remnant Medic") && wear_id)
 		var/obj/item/card/id/idcard = wear_id.GetID()
 		if(istype(idcard))
 			return idcard.registered_name

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -160,13 +160,14 @@
 			continue
 		//This entire if/else chain could be in two lines but isn't for readabilty's sake.
 		var/msg = message
-		if(M.see_invisible<invisibility || (T != loc && T != src))//if src is invisible to us or is inside something (and isn't a turf),
+		if(M.see_invisible < invisibility || (T != loc && T != src && !istype(loc, /mob/living)))//if src is invisible to us or is inside something (and isn't a turf),
 			msg = blind_message
 
 		if(visible_message_flags & EMOTE_MESSAGE && runechat_prefs_check(M, visible_message_flags) && !M.is_blind())
 			M.create_chat_message(src, raw_message = raw_msg, runechat_flags = visible_message_flags)
 
-		M.show_message(msg, MSG_VISUAL, blind_message, MSG_AUDIBLE)
+		if(msg)
+			M.show_message(msg, MSG_VISUAL, blind_message, MSG_AUDIBLE)
 
 ///Adds the functionality to self_message.
 /mob/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, mob/target, target_message, visible_message_flags = NONE)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -187,7 +187,8 @@
 			B.forceMove(T)
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user
-				B.add_blood_DNA(C.dna, C.diseases)
+				var/list/blood_dna = C.get_blood_dna_list()
+				B.add_blood_DNA(blood_dna, C.diseases)
 			var/datum/callback/gibspawner = CALLBACK(user, /mob/living/proc/spawn_gibs, FALSE, B)
 			B.throw_at(target, BRAINS_BLOWN_THROW_RANGE, BRAINS_BLOWN_THROW_SPEED, callback=gibspawner)
 			return(BRUTELOSS)


### PR DESCRIPTION
fixes a bunch of runtimes

-two handed weapons being wileded by floor tiles (lol)
-windows not taking kindly armour penetration
-formalize a signal override
-most empty to_Chats problems
-midless voices unemployment problems
-legacy lock runtime (why do we even use those locks?)
-quirks lose empty message runtime fix
-flashbang lights badly written
-stops some extra damage checks on deleted objets
-fixes gang sending runtimes instead of visible messages
-proto kinectis extra damage now properly applies and doesn't runtimes
-heavy sabres has a natural weapon but the no longer do they populate 
-ghost without clients won't get ghost verbs
-killing yourself with a gun won't also kill the server anymore