### PR TITLE
Mole Miner Gauntlet Buff

### DIFF
--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -90,7 +90,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	hitsound = 'sound/weapons/bap.ogg'
 	flags_1 = CONDUCT_1
-	force = 15
+	force = 25
 	throw_distance = 5
 	throwforce = 10
 	throw_range = 7


### PR DESCRIPTION
Makes mole miner actually usable in combat, changes from 15-25 damage like the rest of the powerfists.
