### PR TITLE
Revolver edits

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -212,6 +212,7 @@
 	extra_damage = 28
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev357
 	w_class = WEIGHT_CLASS_SMALL
+	weapon_weight = WEAPON_LIGHT
 	spread = 2
 	fire_sound = 'sound/f13weapons/policepistol.ogg'
 
@@ -263,6 +264,7 @@
 	desc = "A snubnose variant of the commonplace .44 magnum. An excellent holdout weapon for self defense."
 	icon_state = "m29_snub"
 	w_class = WEIGHT_CLASS_SMALL
+	weapon_weight = WEAPON_LIGHT
 	extra_damage = 35
 	spread = 3
 
@@ -379,8 +381,8 @@
 	icon_state = "contender"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev45/gunslinger/contender
 	weapon_weight = WEAPON_MEDIUM
-	extra_damage = 40
-	extra_penetration = 0.1
+	extra_damage = 60
+	extra_penetration = 0.5
 	fire_delay = 4.5
 	spread = 0
 	fire_sound = 'sound/f13weapons/boltfire.ogg'

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -211,8 +211,7 @@
 	icon_state = "police"
 	extra_damage = 28
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev357
-	w_class = WEIGHT_CLASS_SMALL
-	weapon_weight = WEAPON_LIGHT
+	w_class = WEIGHT_CLASS_TINY
 	spread = 2
 	fire_sound = 'sound/f13weapons/policepistol.ogg'
 
@@ -263,8 +262,7 @@
 	name = "snubnose .44 magnum revolver"
 	desc = "A snubnose variant of the commonplace .44 magnum. An excellent holdout weapon for self defense."
 	icon_state = "m29_snub"
-	w_class = WEIGHT_CLASS_SMALL
-	weapon_weight = WEAPON_LIGHT
+	w_class = WEIGHT_CLASS_TINY
 	extra_damage = 35
 	spread = 3
 


### PR DESCRIPTION

## About The Pull Request

Buffs the Thompson Contender to make it compete with other revolvers. Buffs the police revolver and snubnose .44 to fit into the boot. 

## Why It's Good For The Game

A lot of the revolvers coded into the game are generally underpowered and underutilized, and it was bothering me how shitty the Thompson Contender is compared to the other revolvers in the game. This should help put Thompson Contender back into the field as a decent competitor to other revolvers. 

I also hated how the snubnose version of .44 and .357 are ultimately obsolete to use with how storage and DPS works on this server. Being able to fit them into the boot should make them into true holdout weapons and add a bit of a stealthy edge that the long-barreled revolvers don't have. 

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.



## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
balance: Increased Thompson Contender damage by 20 brute. Gave it a bit more AP.
balance: The .44 and .357 snubnose SHOULD fit into the boot now.
/:cl:

