### PR TITLE
Update shotgun.dm

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -147,8 +147,10 @@
 	..()
 
 /obj/item/projectile/bullet/pellet/trainshot
-	damage = 11 // less pellets, more dam + tiny bit of pen
-	armour_penetration = 0.4
+	damage = 14 // less pellets, more dam + tiny bit of pen
+	armour_penetration = 0.6
+	stamina = 20
+	knockdown = 40
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/pellet/trainshot/on_hit(atom/target)


### PR DESCRIPTION

## About The Pull Request

Gives trainshot a good buff - more AP, more damage, and now it'll deal a tiny bit of stamina damage. 

## Why It's Good For The Game

Shotguns were grudgecoded into oblivion a year ago and it never recovered. Shotguns in general just can't compete at the moment with the armor power creep, leaving it to decay as an obscure weapon in the armory that nobody really uses. 

This buff should give shotguns their own niche against heavily armored enemies, and bring it back into the battlefield as a competitive force to be reckoned with.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.



## Changelog

:cl:
add: Added stam damage to trainshot pellets.
add: Added knockdown to trainshot pellets (if the trainshot knockback causes someone to hit a wall, they fall down like they're being shoved)
tweak: Tweaked trainshot AP to do a bit more.
balance: Increased trainshot damage. (11 --> 14 )
/:cl: