### PR TITLE
Trainshot Tweaks

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -149,8 +149,7 @@
 /obj/item/projectile/bullet/pellet/trainshot
 	damage = 14 // less pellets, more dam + tiny bit of pen
 	armour_penetration = 0.6
-	stamina = 20
-	knockdown = 40
+	stamina = 10
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/pellet/trainshot/on_hit(atom/target)


### PR DESCRIPTION

## About The Pull Request

Trainshot does a little too much stamina damage. Rangers were exploiting it with citykillers the other day. Not cool bro. This should fix it. 

## Why It's Good For The Game

People will stop telling me to kill myself in general chat for buffing trainshot. Removes exploitable mechanics. 

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog

:cl:
del: Removed knockback function. 
tweak: Tweaked stam damage (20 -> 10)
/:cl:

