### PR TITLE
Slight 2H weapon buffs

### DIFF
--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -98,7 +98,7 @@
 /obj/item/twohanded/fireaxe/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 80, 0 , hitsound) //axes are not known for being precision butchering tools
-	AddComponent(/datum/component/two_handed, force_unwielded=26, force_wielded=46, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded=26, force_wielded=40, icon_wielded="[icon_prefix]2")
 
 /obj/item/twohanded/fireaxe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] axes [user.p_them()]self from head to toe! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -133,6 +133,8 @@
 	icon_state = "boneaxe"
 	icon_prefix = "boneaxe"
 	resistance_flags = null
+	supereffective_damage = 20
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 
 /obj/item/twohanded/fireaxe/boneaxe/ComponentInitialize()
 	. = ..()
@@ -298,10 +300,11 @@
 	icon_prefix = "lance"
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
+	armour_penetration = 0.10
 
 /obj/item/twohanded/spear/lance/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=15, force_wielded=30, icon_wielded="[icon_prefix]_wield")
+	AddComponent(/datum/component/two_handed, force_unwielded=15, force_wielded=35, icon_wielded="[icon_prefix]_wield")
 
 
 // Scrap spear		Keywords: Damage 17/28, Reach, Throw bonus

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -206,6 +206,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
 	ADD_TRAIT(H, TRAIT_SELF_AWARE, src)
+	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
 	if(H.mind)
 		var/obj/effect/proc_holder/spell/terrifying_presence/S = new /obj/effect/proc_holder/spell/terrifying_presence
 		H.mind.AddSpell(S)
@@ -296,6 +297,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	ADD_TRAIT(H, TRAIT_SELF_AWARE, src)
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
+	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
+	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
 
 
 //NCR STAFF SERGEANT
@@ -314,6 +317,11 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY, ACCESS_NCR1, ACCESS_NCR2, ACCESS_NCR_COMMAND, ACCESS_PUBLIC, ACCESS_NCR3)
 
+	loadout_options = list(
+		/datum/outfit/loadout/staffsergeantsharpshooter,
+		/datum/outfit/loadout/staffsergeantmanatarms
+		)
+
 /datum/outfit/job/ncr/f13staffsergeant	
 	name = "NCR Staff Sergeant"
 	jobtype	= /datum/job/ncr/f13staffsergeant
@@ -327,28 +335,44 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	gloves = /obj/item/clothing/gloves/f13/leather
 	ears = /obj/item/radio/headset/headset_ncr_com
 	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/lieutenant
-	suit_store = /obj/item/gun/ballistic/automatic/m1garand
 	r_pocket = /obj/item/binoculars
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/bayonet = 1,
-		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
-		/obj/item/ammo_box/magazine/m9mmds = 3,
+		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
+		/obj/item/ammo_box/magazine/m45exp = 3,
 		/obj/item/storage/bag/money/small/ncrofficers = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
 		/obj/item/book/manual/ncr/jobguide/regs = 1,
 		/obj/item/storage/box/ration/menu_eleven = 1,
-		/obj/item/ammo_box/magazine/garand308 = 4,
-		/obj/item/attachments/scope = 1,
 		/obj/item/storage/box/ration/menu_five = 1
 		)
 
-/datum/outfit/job/ncr/f13lieutenant/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/loadout/staffsergeantsharpshooter
+	name = "Sharpshooter"
+	suit_store = /obj/item/gun/ballistic/automatic/m1garand
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/garand308 = 4,
+		/obj/item/melee/onehanded/knife/bowie = 1
+		/obj/item/attachments/scope = 1,
+		)
+	
+/datum/outfit/loadout/staffsergeantmanatarms
+	name = "Man-At-Arms"
+	suit_store = /obj/item/gun/ballistic/automatic/service/r82
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/m556/rifle = 3,
+		/obj/item/melee/onehanded/knife/bowie = 1,
+		)
+
+/datum/outfit/job/ncr/f13staffsergeant/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	ADD_TRAIT(H, TRAIT_SELF_AWARE, src)
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
+	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
+	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
 
 // SERGEANT PILOT
 
@@ -438,6 +462,12 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/binoculars = 1
 		)
+
+/datum/outfit/job/ncr/f13sergeant/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 
 // REPRESENATIVE
 
@@ -923,6 +953,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		return
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_LOW, src)
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/medx)
 
 /////////////////////////

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -352,8 +352,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	suit_store = /obj/item/gun/ballistic/automatic/m1garand
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/garand308 = 4,
-		/obj/item/melee/onehanded/knife/bowie = 1
-		/obj/item/attachments/scope = 1,
+		/obj/item/melee/onehanded/knife/bowie = 1,
+		/obj/item/attachments/scope = 1
 		)
 	
 /datum/outfit/loadout/staffsergeantmanatarms
@@ -361,7 +361,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	suit_store = /obj/item/gun/ballistic/automatic/service/r82
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556/rifle = 3,
-		/obj/item/melee/onehanded/knife/bowie = 1,
+		/obj/item/melee/onehanded/knife/bowie = 1
 		)
 
 /datum/outfit/job/ncr/f13staffsergeant/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)


### PR DESCRIPTION

## About The Pull Request

Gives some small buffs and balances for niche 2H weapons.

## Why It's Good For The Game

Took in community feedback regarding melee weapons. They're a _little_ underpowered in both PVE and PVP. This should add a bit more flavor to what type of weapon you want to use. 

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
add: Added extra mob damage (+20) to the bone axe to fit the description. Go smack some deathclaws.
add: Added 10% AP and a little extra damage to the Legion lance.
tweak: Lowered fire axe damage by a little bit to compensate for the 20% AP.
/:cl:

