### PR TITLE
NICHE MELEE BUFFS + LEGION LOADOUT REWORK

### DIFF
--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -102,7 +102,8 @@
 	desc = "This long blade is favoured by Legion officers and leaders, a finely crafted weapon with good steel and hilt made from bronze and bone."
 	icon_state = "spatha"
 	item_state = "spatha"
-	force = 38
+	force = 42
+	armour_penetration = 0.10
 	wound_bonus = 30
 	block_chance = 18
 
@@ -111,7 +112,7 @@
 	desc = "A long one-handed blade sporting lovingly applied wraps and a wonderfully forged and engraved guard. The blade looks to be carefully sharpened."
 	icon_state = "longblade"
 	item_state = "longblade"
-	force = 38
+	force = 39
 	block_chance = 18
 
 /obj/item/melee/onehanded/machete/scrapsabre
@@ -133,10 +134,10 @@
 	icon_state = "throw_spear"
 	item_state = "tribalspear"
 	force = 20
-	throwforce = 35
-	armour_penetration = 0.10
+	throwforce = 40
+	armour_penetration = 0.30
 	max_reach = 2
-	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 8)
+	embedding = list("pain_mult" = 4, "embed_chance" = 85, "fall_chance" = 8)
 	w_class = WEIGHT_CLASS_NORMAL
 
 
@@ -233,7 +234,8 @@
 	icon_state = "knife_trench"
 	item_state = "knife_trench"
 	desc = "This blade is designed for brutal close quarters combat."
-	force = 31
+	force = 33
+	wound_bonus = 10
 	custom_materials = list(/datum/material/iron=8000)
 	attack_verb = list("slashed", "stabbed", "sliced", "shanked", "ripped", "lacerated")
 
@@ -360,12 +362,12 @@
 	desc = "a finely balanced knife made from a lightweight alloy, designed for being thrown. You can easily embed these in someone, and you look darn cool while doing so."
 	icon_state = "knife_throw"
 	force = 20
-	throwforce = 23
+	throwforce = 27
 	armour_penetration = 0.25
 	bare_wound_bonus = 15 //keep your arteries covered
 	throw_speed = 5
 	throw_range = 7
-	embedding = list("pain_mult" = 4, "embed_chance" = 70, "fall_chance" = 5)
+	embedding = list("pain_mult" = 4, "embed_chance" = 75, "fall_chance" = 5)
 
 ///////////
 // CLUBS //
@@ -428,6 +430,14 @@
 	force = 26
 	block_chance = 30
 	attack_verb = list("smacked", "thwacked", "democratized", "freedomed")
+
+// Because it's extremely funny
+/obj/item/melee/onehanded/club/ncrflag(mob/living/M, mob/living/user)
+	. = ..()
+	if(!istype(M))
+		return
+	M.apply_damage(20, STAMINA, "chest", M.run_armor_check("chest", "melee"))
+
 
 // Classic Baton
 /obj/item/melee/classic_baton
@@ -754,7 +764,8 @@
 	icon_state = "spiked"
 	item_state = "spiked"
 	sharpness = SHARP_POINTY
-	force = 25
+	force = 26
+	armour_penetration = 0.2
 
 // Sappers			Keywords: Damage 25
 /obj/item/melee/unarmed/sappers
@@ -769,7 +780,7 @@
 	. = ..()
 	if(!istype(M))
 		return
-	M.apply_damage(15, STAMINA, "head", M.run_armor_check("head", "melee"))
+	M.apply_damage(25, STAMINA, "head", M.run_armor_check("head", "melee"))
 
 // Tiger claws		Keywords: Damage 31, Pointy, 0.1 AP
 /obj/item/melee/unarmed/tigerclaw
@@ -792,7 +803,7 @@
 	item_state = "lacerator"
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 27
-	bare_wound_bonus = 5
+	bare_wound_bonus = 15
 	sharpness = SHARP_EDGED
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -879,7 +890,13 @@
 	hitsound = 'sound/f13weapons/pan.ogg'
 	custom_materials = list(/datum/material/iron = 4000)
 
-// Entrenching tool P81
+/obj/item/melee/onehanded/club/fryingpan(mob/living/M, mob/living/user)
+	. = ..()
+	if(!istype(M))
+		return
+	M.apply_damage(20, STAMINA, "chest", M.run_armor_check("chest", "melee"))
+
+// Entrenching tool P81 (based, they deserve better if they're using this)
 /obj/item/shovel/trench
 	name = "p81 entrenching tool"
 	desc = "The 'Pattern 2281' Entrenching Tool is a new piece of infantry equipment given in limited quantity to infantry troops. An extremely robust shovel with a serrated edge for chopping wood."
@@ -889,7 +906,8 @@
 	icon_state = "entrenching_tool"
 	item_state = "trench"
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 30
+	force = 35
+	armour_penetration = 0.2
 	throwforce = 15
 	toolspeed = 0.7
 	sharpness = SHARP_EDGED

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -86,7 +86,7 @@
 	. = ..()
 	if(!istype(M))
 		return
-	M.apply_damage(20, STAMINA, "chest", M.run_armor_check("chest", "melee"))
+	M.apply_damage(25, STAMINA, "chest", M.run_armor_check("chest", "melee"))
 
 /obj/item/melee/onehanded/machete/gladius
 	name = "gladius"
@@ -430,14 +430,6 @@
 	force = 26
 	block_chance = 30
 	attack_verb = list("smacked", "thwacked", "democratized", "freedomed")
-
-// Because it's extremely funny
-/obj/item/melee/onehanded/club/ncrflag(mob/living/M, mob/living/user)
-	. = ..()
-	if(!istype(M))
-		return
-	M.apply_damage(20, STAMINA, "chest", M.run_armor_check("chest", "melee"))
-
 
 // Classic Baton
 /obj/item/melee/classic_baton
@@ -889,12 +881,6 @@
 	throwforce = 20
 	hitsound = 'sound/f13weapons/pan.ogg'
 	custom_materials = list(/datum/material/iron = 4000)
-
-/obj/item/melee/onehanded/club/fryingpan(mob/living/M, mob/living/user)
-	. = ..()
-	if(!istype(M))
-		return
-	M.apply_damage(20, STAMINA, "chest", M.run_armor_check("chest", "melee"))
 
 // Entrenching tool P81 (based, they deserve better if they're using this)
 /obj/item/shovel/trench

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -56,7 +56,7 @@
 	lefthand_file = 'modular_BD2/legio_invicta/icons/onmob_legion_lefthand.dmi'
 	icon_state = "goliath"
 	item_state = "goliath"
-	force = 25
+	force = 30
 	throw_distance = 3
 
 
@@ -122,8 +122,8 @@
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
 	slot_flags = ITEM_SLOT_SUITSTORE | ITEM_SLOT_BELT
 	force = 10
-	wound_bonus = 25
-	block_chance = 15
+	wound_bonus = 15
+	block_chance = 5
 	throw_speed = 3
 	throw_range = 4
 	throwforce = 10
@@ -135,7 +135,7 @@
 	var/on_item_state = "ripper_on"
 	var/off_item_state = "ripper"
 	var/weight_class_on = WEIGHT_CLASS_HUGE
-	var/force_on = 45
+	var/force_on = 43
 	var/force_off = 10
 	var/on = FALSE
 	var/on_icon_state = "ripper_on"
@@ -288,7 +288,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	item_flags = ABSTRACT  // don't put in storage
 	slot_flags = 0
-	force = 55
+	force = 60
 	damtype = "fire"
 	tool_behaviour = TOOL_WELDER
 	toolspeed = 0.3

--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -52,7 +52,7 @@
 /obj/item/twohanded/legionaxe/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 80, 0 , hitsound) //axes are not known for being precision butchering tools
-	AddComponent(/datum/component/two_handed, force_unwielded=25, force_wielded=50, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded=25, force_wielded=56, icon_wielded="[icon_prefix]2")
 
 /obj/item/twohanded/legionaxe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] axes [user.p_them()]self from head to toe! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -98,7 +98,7 @@
 /obj/item/twohanded/fireaxe/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 80, 0 , hitsound) //axes are not known for being precision butchering tools
-	AddComponent(/datum/component/two_handed, force_unwielded=26, force_wielded=46, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded=26, force_wielded=40, icon_wielded="[icon_prefix]2")
 
 /obj/item/twohanded/fireaxe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] axes [user.p_them()]self from head to toe! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -136,7 +136,7 @@
 
 /obj/item/twohanded/fireaxe/boneaxe/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=25, force_wielded=40, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded=25, force_wielded=50, icon_wielded="[icon_prefix]2")
 
 /obj/item/twohanded/fireaxe/boneaxe/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -298,10 +298,12 @@
 	icon_prefix = "lance"
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
+	armour_penetration = 0.10
+
 
 /obj/item/twohanded/spear/lance/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=15, force_wielded=30, icon_wielded="[icon_prefix]_wield")
+	AddComponent(/datum/component/two_handed, force_unwielded=15, force_wielded=35, icon_wielded="[icon_prefix]_wield")
 
 
 // Scrap spear		Keywords: Damage 17/28, Reach, Throw bonus
@@ -748,8 +750,8 @@
 	icon_state = "chainsaw"
 	icon_prefix = "chainsaw"
 	force = 8
-	wound_bonus = 15
-	bare_wound_bonus = 15
+	wound_bonus = 40
+	bare_wound_bonus = 30
 	sharpness = SHARP_EDGED
 	resistance_flags = FIRE_PROOF
 	attack_verb = list("sawed", "shredded", "mauled")

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -295,15 +295,15 @@
 	mob_overlay_icon = 'modular_BD2/legio_invicta/icons/onmob_legion.dmi'
 	icon_state = "armor_explorer"
 	item_state = "armor_explorer"
-	armor = list("melee" = 40, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 40, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 40)
+	armor = list("melee" = 40, "bullet" = 35, "laser" = 15, "energy" = 10, "bomb" = 40, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 40)
 
 /obj/item/clothing/suit/armor/f13/legion/vet/vexil
 	name = "legion vexillarius armor"
 	desc = " Worn by Vexillarius, this armor has been reinforced with circular metal plates on the chest and a back mounted pole for the flag of the Bull, making the wearer easy to see at a distance."
 	icon_state = "armor_vexillarius"
 	item_state = "armor_vexillarius"
-	armor = list("melee" = 50, "bullet" = 35, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 40)
-	slowdown = 0.08
+	armor = list("melee" = 50, "bullet" = 55, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 40)
+	slowdown = 0.02
 
 /obj/item/clothing/suit/armor/f13/legion/venator
 	name = "legion speculator armor"

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -210,7 +210,6 @@
 	icon_state = "armor_recruit"
 	item_state = "armor_recruit"
 	armor = list("melee" = 40, "bullet" = 20, "laser" = 10, "energy" = 10, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 40)
-	slowdown = 0.04
 
 /obj/item/clothing/suit/armor/f13/legion/recruit/decan
 	name = "legion recruit decanus armor"
@@ -227,7 +226,7 @@
 	icon_state = "armor_prime"
 	item_state = "armor_prime"
 	armor = list("melee" = 50, "bullet" = 30, "laser" = 15, "energy" = 10, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 40)
-	slowdown = 0.05
+	slowdown = 0.03
 
 /obj/item/clothing/suit/armor/f13/legion/prime/decan
 	name = "legion prime decanus armor"
@@ -268,7 +267,7 @@
 	icon_state = "armor_veteran"
 	item_state = "armor_veteran"
 	armor = list("melee" = 55, "bullet" = 35, "laser" = 25, "energy" = 15, "bomb" = 30, "bio" = 5, "rad" = 5, "fire" = 35, "acid" = 0, "wound" = 40)
-	slowdown = 0.05
+	slowdown = 0.03
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 4) // Slightly better armor
 
 /obj/item/clothing/suit/armor/f13/legion/heavy
@@ -297,7 +296,6 @@
 	icon_state = "armor_explorer"
 	item_state = "armor_explorer"
 	armor = list("melee" = 40, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 40, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 40)
-	slowdown = 0.03
 
 /obj/item/clothing/suit/armor/f13/legion/vet/vexil
 	name = "legion vexillarius armor"
@@ -321,7 +319,7 @@
 	icon_state = "legion_centurion"
 	item_state = "legion_centurion"
 	armor = list("melee" = 75, "bullet" = 45, "laser" = 30, "energy" = 25, "bomb" = 45, "bio" = 20, "rad" = 20, "fire" = 45, "acid" = 45, "wound" = 55)
-	slowdown = 0.1
+	slowdown = 0.05
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 10) // Rest in pieces
 
 /obj/item/clothing/suit/armor/f13/legion/palacent //laser resist spec
@@ -329,7 +327,7 @@
 	desc = "A Centurion able to defeat a Brotherhood Paladin gets the honorific title 'Paladin-Slayer', and adds bits of the looted armor to his own."
 	icon_state = "legion_palacent"
 	item_state = "legion_palacent"  // Inconsistent naming, clean all of the sprites and code up sometime
-	armor = list("melee" = 35, "bullet" = 45, "laser" = 50, "energy" = 35, "bomb" = 35, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 75)
+	armor = list("melee" = 35, "bullet" = 50, "laser" = 55, "energy" = 35, "bomb" = 35, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 75)
 	slowdown = 0.1
 
 /obj/item/clothing/suit/armor/f13/legion/rangercent //speed and bullet resist, sacrifices all else
@@ -337,8 +335,7 @@
 	desc = "Centurions who have led many patrols and ambushes against NCR Rangers have a distinct look from the many looted pieces of Ranger armor, and are often experienced in skirmishing."
 	icon_state = "legion_rangercent"
 	item_state = "legion_rangercent"
-	armor = list("melee" = 35, "bullet" = 55, "laser" = 30, "energy" = 25, "bomb" = 35, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0, "wound" = 55)
-	slowdown = 0.05
+	armor = list("melee" = 35, "bullet" = 60, "laser" = 30, "energy" = 25, "bomb" = 35, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0, "wound" = 55)
 
 /obj/item/clothing/suit/armor/f13/legion/legate
 	name = "legion legate armor"
@@ -968,7 +965,7 @@
 	item_state = "Enclave_combatarmor"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	blocks_shove_knockdown = TRUE
-	armor = list("melee" = 35, "bullet" = 40, "laser" = 25, "energy" = 25, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30, "wound" = 40)
+	armor = list("melee" = 35, "bullet" = 30, "laser" = 25, "energy" = 25, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30, "wound" = 20)
 	strip_delay = 80
 	equip_delay_other = 60
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -664,7 +664,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	name = "Sniper"
 	suit_store = /obj/item/gun/ballistic/automatic/m1garand/sks
 	backpack_contents = list(
-		mag_type = /obj/item/ammo_box/magazine/sks = 3,
+		/obj/item/ammo_box/magazine/sks = 3,
 		/obj/item/attachments/scope = 1,
 		/obj/item/melee/onehanded/machete/gladius = 1,
 		/obj/item/grenade/smokebomb = 2

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -248,7 +248,8 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m14mm = 2,
 		/obj/item/melee/unarmed/powerfist/goliath = 1,
-		/obj/item/book/granter/martial/wrestling = 1
+		/obj/item/book/granter/martial/wrestling = 1,
+		/obj/item/reagent_containers/pill/patch/healingpowder/berserker = 2
 		)
 
 
@@ -312,7 +313,8 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit_store = /obj/item/twohanded/sledgehammer/supersledge
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola/tactical = 1,
-		/obj/item/grenade/smokebomb = 1
+		/obj/item/grenade/smokebomb = 1,
+		/obj/item/reagent_containers/pill/patch/bitterdrink = 2
 		)
 
 /datum/outfit/loadout/decvetwolf
@@ -332,7 +334,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	backpack_contents = list(
 		/obj/item/ammo_box/tube/c4570 = 3,
 		/obj/item/attachments/scope = 1,
-		/obj/item/melee/onehanded/machete/spatha,
+		/obj/item/melee/onehanded/machete/spatha = 1,
 		/obj/item/reagent_containers/pill/patch/bitterdrink = 2
 		)
 
@@ -578,18 +580,20 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/combvexil
 	neck = /obj/item/storage/belt/sabre/heavy
 	backpack_contents = list(
-		/obj/item/melee/unarmed/tigerclaw = 1,
+		/obj/item/melee/unarmed/powerfist = 1,
 		/obj/item/melee/powered/ripper = 1,
-		/obj/item/book/granter/martial/wrestling = 1
+		/obj/item/book/granter/martial/wrestling = 1,
+		/obj/item/reagent_containers/pill/patch/healingpowder/berserker = 3
 		)
 
 /datum/outfit/loadout/vexfox
 	name = "Desert Fox"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/vexil
 	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/smg/cg45 = 1,
-		/obj/item/ammo_box/magazine/cg45 = 4,
-		/obj/item/melee/onehanded/machete/spatha = 1
+		/obj/item/gun/ballistic/automatic/smg/american180 = 1,
+		/obj/item/ammo_box/magazine/m22smg = 1,
+		/obj/item/gun/ballistic/revolver/contender = 1,
+		/obj/item/ammo_box/a45lcrev = 3
 		)
 
 /datum/outfit/loadout/vexnight
@@ -658,11 +662,12 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 
 /datum/outfit/loadout/sniper
 	name = "Sniper"
-	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail
+	suit_store = /obj/item/gun/ballistic/automatic/m1garand/sks
 	backpack_contents = list(
-		/obj/item/ammo_box/tube/m44 = 4,
+		mag_type = /obj/item/ammo_box/magazine/sks = 3,
 		/obj/item/attachments/scope = 1,
-		/obj/item/melee/onehanded/machete/gladius = 1
+		/obj/item/melee/onehanded/machete/gladius = 1,
+		/obj/item/grenade/smokebomb = 2
 		)
 
 /datum/outfit/loadout/skirmisher
@@ -671,7 +676,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/cg45 = 2,
 		/obj/item/melee/onehanded/machete/gladius = 1,
-		/obj/item/grenade/smokebomb = 2
+		/obj/item/grenade/homemade/firebomb = 2
 		)
 
 // ----------------- FRUMENTARIUS ---------------------
@@ -680,11 +685,10 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	title = "Legion Frumentarius"
 	flag = F13FRUMENTARIUS
 	display_order = JOB_DISPLAY_ORDER_FRUMENTARIUS
-	description = "The Eyes and Ears of Caesar. Frumentarii cover a wide range of specializations, from Ambassadors to local Tribes, Infiltrators of enemy societies, Couriers, Intelligence Gatherers and the Secret Police of Legion Camps. Unlike the lesser Legionaries, a Frumentarius is given much unsupervised freedom to do as one pleases, so long as the Legion's goals are accomplished. You are one of these Frumentarius. Spread Caesar's Will, for Mars is watching."
-	supervisors = "the Vet Decanus"
-	selection_color = "#ffdddd"
 	total_positions = 2
 	spawn_positions = 2
+	description = "The Eyes and Ears of Caesar. Frumentarii cover a wide range of specializations, from Ambassadors to local Tribes, Infiltrators of enemy societies, Couriers, Intelligence Gatherers and the Secret Police of Legion Camps. Unlike the lesser Legionaries, a Frumentarius is given much unsupervised freedom to do as one pleases, so long as the Legion's goals are accomplished. You are one of these Frumentarius. Spread Caesar's Will, for Mars is watching."
+	supervisors = "the Vet Decanus and Centurion"
 	exp_requirements = 600
 
 	outfit = /datum/outfit/job/CaesarsLegion/Legionary/f13frumentarius
@@ -709,7 +713,8 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	backpack_contents = list(
 		/obj/item/binoculars = 1,
 		/obj/item/ammo_box/a357 = 2,
-		/obj/item/reagent_containers/pill/patch/bitterdrink = 2
+		/obj/item/reagent_containers/pill/patch/bitterdrink = 2,
+		/obj/item/clothing/mask/infiltrator = 1
 		)
 
 /datum/outfit/job/CaesarsLegion/Legionary/f13frumentarius/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -1000,7 +1000,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/ammo_box/magazine/m45 = 2,
 		/obj/item/shovel/trench = 1,
 		/obj/item/book/granter/trait/bigleagues = 1,
-		/obj/item/storage/box/ration/menu_seven = 1
+		/obj/item/storage/box/ration/menu_seven = 1,
+		/obj/item/clothing/suit/armor/f13/ncrarmor/mantle/reinforced/trenchraider = 1
 		)
 
 // TROOPER


### PR DESCRIPTION

## About The Pull Request

Spend a few hours taking in community feedback regarding Legion and Melee.
Gives actual incentive to use melee, gives lesser-used Legion roles some actually decent gear. 

## Why It's Good For The Game

Buffing melee weapons (1H, 2H, Unarmed) incentivizes melee combat more than backpedaling and going pew pew with a Tier 5/6 gun. A lot of melee weapons have a bit more bite against plated armor and wound more. Throwable weapons are also better baby wooo

Legion loadouts were littered with buggy code and half-baked items that haven't been changed in months. Giving them all a little update should encourage more of the playerbase to play Legion. 

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog

:cl:
add: Reworked the Vex, Warlord Cent, Frumentarius, Explorer, and Vet Decanus loadouts. 
add: Added slight AP to several Legion weapons. 
tweak: Slightly enclave private armor so that it isn't roundstart CA.
tweak: Threw in a unique trench raider armor for a Corporal loadout.
balance: Legion armor slowdown is VERY slightly faster now. 
balance: Several 2H, 1H, and Unarmed weapons deal more damage, have small amounts of AP, or do extra wound. 
balance: Throwing spear embed chance is higher now; deals more throw damage.
fix: Vet Decanus loadouts are no longer bugged.
/:cl:
