### PR TITLE
Balances Gauss rifle so it's not a two-shot through PA

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1485,7 +1485,7 @@
 	item_state = "sniper"
 	slot_flags = SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/m2mm
-	extra_damage = 60
+	extra_damage = 40
 	burst_size = 1
 	fire_delay = 10
 	zoomable = TRUE

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1485,7 +1485,7 @@
 	item_state = "sniper"
 	slot_flags = SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/m2mm
-	extra_damage = 40
+	extra_damage = 50
 	burst_size = 1
 	fire_delay = 10
 	zoomable = TRUE


### PR DESCRIPTION

## About The Pull Request

No this isn't grudgecode, idk why the Gauss rifle deals almost double the damage of an AMR.

## Why It's Good For The Game

HP should not get an instakill gun lol

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog

:cl:

balance: Gauss rifle damage 60 -> 40

/:cl:
