### PR TITLE
Switches CQC to ranger-hunter from Warlord

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -229,28 +229,27 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		)
 
 /datum/outfit/loadout/rangerhunter
-	name = "Ranger-Hunter Centurion"
-	suit = /obj/item/clothing/suit/armor/f13/legion/rangercent
-	head = /obj/item/clothing/head/helmet/f13/legion/rangercent
-	suit_store = /obj/item/gun/ballistic/rifle/mag/antimateriel
-	backpack_contents = list(
-		/obj/item/gun/ballistic/revolver/hunting = 1,
-		/obj/item/ammo_box/magazine/amr = 2,
-		/obj/item/ammo_box/c4570 = 3,
-		/obj/item/melee/onehanded/machete/spatha = 1
-		)
+    name = "Ranger-Hunter Centurion"
+    suit = /obj/item/clothing/suit/armor/f13/legion/rangercent
+    head = /obj/item/clothing/head/helmet/f13/legion/rangercent
+    suit_store = /obj/item/gun/ballistic/rifle/mag/antimateriel
+    backpack_contents = list(
+        /obj/item/gun/ballistic/revolver/hunting = 1,
+        /obj/item/ammo_box/magazine/amr = 2,
+        /obj/item/ammo_box/c4570 = 3,
+        /obj/item/book/granter/martial/cqc = 1
+        )
 
 /datum/outfit/loadout/centurion
-	name = "Warlord Centurion"
-	suit = /obj/item/clothing/suit/armored/heavy/legion/centurion
-	head = /obj/item/clothing/head/helmet/f13/legion/centurion
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/pistol14
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m14mm = 2,
-		/obj/item/melee/unarmed/powerfist/goliath = 1,
-		/obj/item/book/granter/martial/cqc = 1,
-		/obj/item/reagent_containers/pill/patch/healingpowder/berserker = 2
-		)
+    name = "Warlord Centurion"
+    suit = /obj/item/clothing/suit/armored/heavy/legion/centurion
+    head = /obj/item/clothing/head/helmet/f13/legion/centurion
+    suit_store = /obj/item/gun/ballistic/automatic/pistol/pistol14
+    backpack_contents = list(
+        /obj/item/ammo_box/magazine/m14mm = 2,
+        /obj/item/melee/unarmed/powerfist/goliath = 1,
+        /obj/item/reagent_containers/pill/patch/healingpowder/berserker = 2
+        )
 
 
 // ----------------- VETERAN DECANUS ---------------------


### PR DESCRIPTION
Switches CQC to ranger-hunter from Warlord

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Takes the goliath off of the Centurion Warlord and gives it to the ranger hunter. Currently Warlord gets both CQC and the goliath making one redundant most of the time, He does not need to start with two extremely powerful melee weapons as both are fully functional on their own. Instead i've moved CQC over to the Ranger-hunter who is somewhat underwhelming when i use it even if it has a AMR and it makes more sense considering based on his armor he's fought many rangers in combat and would have studied their CQC techniques and adapted them to his own usage.

## Why It's Good For The Game

Balances out the centurion loadouts so people use other loadouts then just warlord and palacent. Currently Ranger-hunter atleast in my usage is underwhelming at best.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


