### PR TITLE
Bringing Back Dual Wielding + Ranger Ocelot

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -607,11 +607,11 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		)
 
 /datum/outfit/loadout/vrshotgunner
-	name = "Veteran Ranger Shotgunner"
-	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/neostead
+	name = "Veteran Ranger Ocelot"
 	backpack_contents = list(
 		/obj/item/storage/box/ration/ranger_breakfast = 1,
-		/obj/item/ammo_box/shotgun/buck = 3
+		/obj/item/gun/ballistic/revolver/sequoia = 1,
+		/obj/item/ammo_box/c4570 = 3
 		)
 
 /datum/outfit/job/ncr/f13vetranger/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -572,7 +572,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	id = /obj/item/card/id/dogtag/ncrvetranger
 	uniform = /obj/item/clothing/under/f13/ranger/vet
 	suit = /obj/item/clothing/suit/armor/f13/rangercombat
-	suit_store = /obj/item/gun/ballistic/revolver/sequoia
 	head = /obj/item/clothing/head/helmet/f13/ncr/rangercombat
 	gloves = /obj/item/clothing/gloves/rifleman
 	shoes = /obj/item/clothing/shoes/f13/military/leather
@@ -587,7 +586,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/storage/bag/money/small/ncrofficers = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
 		/obj/item/grenade/smokebomb = 1,
-		/obj/item/ammo_box/c4570 = 3
 		)
 
 /datum/outfit/loadout/vrclassic
@@ -595,7 +593,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	suit_store = /obj/item/gun/ballistic/rifle/mag/antimateriel
 	backpack_contents = list(
 		/obj/item/storage/box/ration/ranger_dinner = 1,
-		/obj/item/ammo_box/magazine/amr = 2
+		/obj/item/ammo_box/magazine/amr = 2,
+		/obj/item/ammo_box/c4570 = 3,
+		/obj/item/gun/ballistic/revolver/sequoia = 1
 		)
 
 /datum/outfit/loadout/vrlite
@@ -603,15 +603,17 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	suit_store = /obj/item/gun/ballistic/rifle/repeater/brush
 	backpack_contents = list(
 		/obj/item/storage/box/ration/ranger_lunch = 1,
-		/obj/item/ammo_box/tube/c4570 = 3
+		/obj/item/ammo_box/tube/c4570 = 3,
+		/obj/item/ammo_box/c4570 = 3,
+		/obj/item/gun/ballistic/revolver/sequoia = 1
 		)
 
 /datum/outfit/loadout/vrshotgunner
 	name = "Veteran Ranger Ocelot"
 	backpack_contents = list(
 		/obj/item/storage/box/ration/ranger_breakfast = 1,
-		/obj/item/gun/ballistic/revolver/sequoia = 1,
-		/obj/item/ammo_box/c4570 = 3
+		/obj/item/gun/ballistic/revolver/revolver45/gunslinger = 2,
+		/obj/item/ammo_box/magazine/internal/cylinder/rev45/gunslinger = 4
 		)
 
 /datum/outfit/job/ncr/f13vetranger/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -221,7 +221,7 @@
 		name = "sawn-off [src.name]"
 		desc = sawn_desc
 		w_class = WEIGHT_CLASS_NORMAL
-		weapon_weight = WEAPON_MEDIUM // Nope. Not unless you want broken wrist.
+		weapon_weight = WEAPON_LIGHT // FUCK IT WE BALL
 		item_state = "gun"
 		slot_flags &= ~ITEM_SLOT_BACK	//you can't sling it on your back
 		slot_flags |= ITEM_SLOT_BELT		//but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -380,13 +380,15 @@
 	icon_state = "uzi"
 	item_state = "uzi"
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
+	weapon_weight = WEAPON_LIGHT
+	w_class = WEIGHT_CLASS_SMALL
 	fire_delay = 3
 	burst_shot_delay = 2.2
 	is_automatic = TRUE
 	automatic = 1
 	slowdown = 0.3
 	autofire_shot_delay = 2
-	spread = 40
+	spread = 60
 	extra_damage = 17
 	can_suppress = TRUE
 	can_attachments = TRUE
@@ -404,7 +406,7 @@
 			spread = 16
 			fire_delay = 3
 			recoil = 0.1
-			weapon_weight = WEAPON_HEAVY
+			weapon_weight = WEAPON_LIGHT
 			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")
 			enable_burst()
 		if(1)
@@ -412,7 +414,7 @@
 			automatic = 0
 			fire_delay = 3
 			spread = 3
-			weapon_weight = WEAPON_MEDIUM
+			weapon_weight = WEAPON_LIGHT
 			to_chat(user, "<span class='notice'>You switch to semi-auto.</span>")
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 	update_icon()

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -183,7 +183,7 @@
 	fire_delay = 2
 	burst_size = 2
 	burst_shot_delay = 2.5
-	spread = 9
+	spread = 4
 	recoil = 0.2
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	automatic_burst_overlay = TRUE
@@ -197,7 +197,7 @@
 		if(0)
 			select += 1
 			burst_size = 2
-			spread = 9
+			spread = 4
 			recoil = 0.1
 			weapon_weight = WEAPON_LIGHT
 			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -110,6 +110,7 @@
 	desc = "Chinese military sidearm at the time of the Great War. The ones around are old and worn, but somewhat popular due to the long barrel and rechambered in 10mm after the original ammo ran dry decades ago."
 	icon_state = "chinapistol"
 	mag_type = /obj/item/ammo_box/magazine/m10mm_adv/simple
+	weapon_weight = WEAPON_LIGHT
 	fire_delay = 1
 	extra_damage = 24
 	recoil = 0.1
@@ -198,14 +199,14 @@
 			burst_size = 2
 			spread = 9
 			recoil = 0.1
-			weapon_weight = WEAPON_HEAVY
+			weapon_weight = WEAPON_LIGHT
 			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")
 		if(1)
 			select = 0
 			burst_size = 1
 			spread = 1
 			recoil = 0
-			weapon_weight = WEAPON_MEDIUM
+			weapon_weight = WEAPON_LIGHT
 			to_chat(user, "<span class='notice'>You switch to semi-auto.</span>")
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 	update_icon()
@@ -218,6 +219,7 @@
 	desc = "A classic .45 handgun with a small magazine capacity."
 	icon_state = "m1911"
 	item_state = "pistolchrome"
+	weapon_weight = WEAPON_LIGHT
 	w_class = WEIGHT_CLASS_NORMAL
 	fire_delay = 2
 	slowdown = 0.05
@@ -272,6 +274,7 @@
 	icon_state = "deagle"
 	item_state = "deagle"
 	mag_type = /obj/item/ammo_box/magazine/m44
+	weapon_weight = WEAPON_LIGHT
 	fire_delay = 3
 	force = 15
 	extra_damage = 38
@@ -301,6 +304,7 @@
 	icon_state = "automag"
 	item_state = "deagle"
 	mag_type = /obj/item/ammo_box/magazine/automag
+	weapon_weight = WEAPON_LIGHT
 	fire_delay = 4
 	extra_damage = 41
 	extra_speed = 300

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -305,7 +305,6 @@
 	desc = "This large, double-action revolver is a trademark weapon of the New California Republic Rangers. It features a dark finish with intricate engravings etched all around the weapon. Engraved along the barrel are the words 'For Honorable Service,' and 'Against All Tyrants.' The hand grip bears the symbol of the NCR Rangers, a bear, and a brass plate attached to the bottom that reads '20 Years.' "
 	icon_state = "sequoia"
 	item_state = "sequoia"
-	weapon_weight = WEAPON_LIGHT
 	recoil = 0.2
 	fire_delay = 1
 	extra_damage = 40
@@ -358,6 +357,7 @@
 	item_state = "coltwalker"
 	icon_state = "peacemaker"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev45/gunslinger
+	weapon_weight = WEAPON_LIGHT
 	extra_damage = 38
 	extra_penetration = 0.15
 	fire_delay = 4.5

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -152,6 +152,7 @@
 	item_state = "45revolver"
 	icon_state = "45revolver"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev45
+	weapon_weight = WEAPON_LIGHT
 	extra_damage = 34
 	fire_delay = 4.5
 	spread = 1
@@ -211,6 +212,7 @@
 	icon_state = "police"
 	extra_damage = 28
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev357
+	weapon_weight = WEAPON_LIGHT
 	w_class = WEIGHT_CLASS_TINY
 	spread = 2
 	fire_sound = 'sound/f13weapons/policepistol.ogg'
@@ -228,6 +230,7 @@
 	item_state = "model29"
 	icon_state = "m29"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev44
+	weapon_weight = WEAPON_LIGHT
 	extra_damage = 35
 	extra_penetration = 0.1
 	recoil = 0.1
@@ -263,6 +266,7 @@
 	desc = "A snubnose variant of the commonplace .44 magnum. An excellent holdout weapon for self defense."
 	icon_state = "m29_snub"
 	w_class = WEIGHT_CLASS_TINY
+	weapon_weight = WEAPON_LIGHT
 	extra_damage = 35
 	spread = 3
 
@@ -274,6 +278,7 @@
 	item_state = "44colt"
 	icon_state = "44colt"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev44
+	weapon_weight = WEAPON_LIGHT
 	fire_delay = 4.5
 	extra_damage = 35
 	spread = 0
@@ -284,6 +289,7 @@
 /obj/item/gun/ballistic/revolver/revolver44/desert_ranger
 	name = "desert ranger revolver"
 	desc = "I hadn't noticed, but there on his hip, was a really spiffy looking iron..."
+	weapon_weight = WEAPON_LIGHT
 	fire_delay = 4
 	extra_penetration = 0.1
 	extra_damage = 40
@@ -299,7 +305,7 @@
 	desc = "This large, double-action revolver is a trademark weapon of the New California Republic Rangers. It features a dark finish with intricate engravings etched all around the weapon. Engraved along the barrel are the words 'For Honorable Service,' and 'Against All Tyrants.' The hand grip bears the symbol of the NCR Rangers, a bear, and a brass plate attached to the bottom that reads '20 Years.' "
 	icon_state = "sequoia"
 	item_state = "sequoia"
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_LIGHT
 	recoil = 0.2
 	fire_delay = 1
 	extra_damage = 40
@@ -365,7 +371,7 @@
 	desc = "A strange pistol firing rifle ammunition, possibly damaging the users wrist and with poor accuracy."
 	icon_state = "thatgun"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/thatgun
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_LIGHT
 	extra_damage = 33
 	extra_penetration = 0.2
 	spread = 4
@@ -398,6 +404,7 @@
 	icon_state = "needler"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/revneedler
 	fire_sound = 'sound/weapons/gunshot_silenced.ogg'
+	weapon_weight = WEAPON_LIGHT
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/gun/ballistic/revolver/needler/ultra

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -209,7 +209,7 @@
 	fire_delay = 0
 	slowdown = 0.2
 	w_class = WEIGHT_CLASS_NORMAL
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_LIGHT
 	slot_flags = ITEM_SLOT_BELT
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/wattz/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
@@ -223,6 +223,7 @@
 	fire_delay = 0
 	item_state = "laser-pistol"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/wattz/magneto/hitscan)
+	weapon_weight = WEAPON_LIGHT
 
 /obj/item/gun/energy/laser/wattz/recharger
 	name = "Recharger Pistol"
@@ -232,7 +233,7 @@
 	selfcharge = 1
 	icon_state = "rechargerpistol"
 	w_class = WEIGHT_CLASS_SMALL
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_LIGHT
 	slot_flags = ITEM_SLOT_BELT
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/recharger/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/breeder
@@ -246,7 +247,7 @@
 	icon_state = "AEP7"
 	item_state = "laser-pistol"
 	w_class = WEIGHT_CLASS_NORMAL
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_LIGHT
 	slot_flags = ITEM_SLOT_BELT
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
@@ -555,7 +556,7 @@
 	icon_state = "ultra_pistol"
 	item_state = "laser-pistol"
 	w_class = WEIGHT_CLASS_NORMAL
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_LIGHT
 	slot_flags = ITEM_SLOT_BELT
 	ammo_type = list(/obj/item/ammo_casing/energy/gammagun)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc


### PR DESCRIPTION

## About The Pull Request

Brings back dual wielding to a solid majority of pistols, revolvers, and other one-handed weapons. Brings back the dual SAA loadout for the Vet Ranger. Slightly buffs Beretta. Slightly increased Uzi's spread.

## Why It's Good For The Game

I have no idea why it was taken out in the first place, feels like grudgecode. Dual wielding is badass, and the accuracy gets awful when you're dual wielding. 

Literally nobody runs the Vet Ranger with the Neostead - some incentive to run anything other than the AMR is always good. 

 Also, the Beretta had godawful stats for some reason, so I thought that should be fixed. Upped the Uzi spread a bit to balance out the dual wielding capabilities.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
add: Brought back dual wielding capabilities to the following pistols: 1911, Deagle, Berettas, Automag, 10mm variants.
add: Added dual wielding to the following miscellaneous guns: Sawed-off shotguns, Uzi.
add: Brought back dual wielding capabilities to the following revolvers: Colt Single-Action Army, .44 Magnum/Snubnosed, Police Revolver, Desert Ranger Revolver, .223 Revolver.
add: Added the Ranger Ocelot Loadout
del: Removed the Vet Ranger shotgunner loadout. 
balance: Slightly buffed the Beretta (lower spread). Slightly nerfed the Uzi (higher spread).
/:cl:

