### PR TITLE
Readds Cryo Grenades to RnD

### DIFF
--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -16,7 +16,7 @@
 	display_name = "Cryostasis Technology"
 	description = "Smart freezing of objects to preserve them!"
 	prereq_ids = list("adv_engi", "biotech")
-	design_ids = list("splitbeaker", "noreactsyringe", "cryotube")
+	design_ids = list("splitbeaker", "noreactsyringe", "cryotube", "cryo_Grenade")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 /*
 /datum/techweb_node/adv_defibrillator_tec


### PR DESCRIPTION


## About The Pull Request

Cryo grenades are readded to the RnD system.

## Why It's Good For The Game

Warcrime grenades were funny :3

A significant chunk of Enclave science mains quit because of all the things being removed from RnD.
Promotion of passive gameplay isn't healthy for Enclave IMO, it neuters the game. 
RnD is one of the biggest advantages the Enclave and BoS have, and removing the shit that makes it fun is grudgecodey.
Instead, I believe we should be promoting more unique playstyles exclusive to Enclave so it's just just metarushing all round.
Literally every round, Enclave just prints out ballistic shields and rush deathclaw caves. It's depressing to see.
Frankly I just really wanna bring back all the chemistry fuckery Enclave used to do. It's a shadow of its former self now.
Obviously some fragmonkeys are gonna get pissed at this, but fuck you, it was fun and I never see scientists anymore.
Old Enclave mains remember the days of acid grenades and other fuckery that we'd airdrop from vertibirds - that was KINO. 
Lesbian femstatics don't even play Enclave anymore. That's how you know the faction's gone to shit. 
Scientist mains, rejoice - your chemical warfare is back, baby.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog

:cl:
add: readded cryo nades
/:cl:

